### PR TITLE
Don't rename device, just update description

### DIFF
--- a/pulsemeeter/MainWindow.py
+++ b/pulsemeeter/MainWindow.py
@@ -207,8 +207,9 @@ class MainWindow(Gtk.Window):
         for i in ['1', '2', '3']:
 
             name = self.pulse.config['vi'][i]['name']
+            desc = self.pulse.config['vi'][i].get('desc', name)
             label = self.builder.get_object(f'vi_{i}_label')
-            label.set_text(name if name != '' else f'Virtual Input {i}')
+            label.set_text(desc if desc != '' else f'Virtual Input {i}')
             label_evt_box = self.builder.get_object(f'vi_{i}_label_event_box')
             label_evt_box.connect('button_press_event', self.label_click, label, ['vi', i])
             primary = self.builder.get_object(f'vi_{i}_primary')
@@ -338,6 +339,7 @@ class MainWindow(Gtk.Window):
         name = widget.get_text()
         if not ' ' in name:
             if self.pulse.rename(self.Label_Index, name) == True:
+                self.pulse.save_config()
                 self.PopActive.set_text(name)
                 self.sink_input_box.load_application_list()
                 self.source_output_box.load_application_list()

--- a/pulsemeeter/Pulse.py
+++ b/pulsemeeter/Pulse.py
@@ -431,13 +431,18 @@ class Pulse:
         name_vi = []
         name_b = []
         for i in ['1','2','3']:
+            vi_name = self.config['vi'][i]['name']
+            vi_desc = self.config['vi'][i].get('desc', vi_name)
             if dev_type == 'source-output':
-                if self.config['b'][i]['name'] != '':
-                    name_b.append(self.config['b'][i]['name'])
-                if self.config['vi'][i]['name'] != '':
-                    name_vi.append(self.config['vi'][i]['name'] + '.monitor')
-            elif self.config['vi'][i]['name'] != '':
-                    name_vi.append(self.config['vi'][i]['name'])
+                b_name = self.config['b'][i]['name']
+                b_desc = self.config['b'][i].get('desc', b_name)
+                if b_desc != '':
+                    name_b.append(b_desc)
+                
+                if vi_desc != '':
+                    name_vi.append(vi_desc + '.monitor')
+            elif vi_desc != '':
+                    name_vi.append(vi_desc)
 
 
         if dev_type == 'source-output':

--- a/pulsemeeter/Pulse.py
+++ b/pulsemeeter/Pulse.py
@@ -79,7 +79,9 @@ class Pulse:
             if self.config['vi'][str(i)]['name'] != '':
                 if not re.search(self.config['vi'][str(i)]['name'], sink_list):
                     sink = self.config['vi'][str(i)]['name']
-                    command = command + f"pmctl init sink {sink}\n"
+                    # Since this variable came later, default to the sink name if it doesn't exist
+                    desc = self.config['vi'][str(i)].get('desc', sink)
+                    command = command + f"pmctl init sink {sink} {desc}\n"
         return command
 
     def start_sources(self):
@@ -89,7 +91,9 @@ class Pulse:
             if self.config['b'][str(i)]['name'] != '':
                 if not re.search(self.config['b'][str(i)]['name'], source_list):
                     source = self.config['b'][str(i)]['name']
-                    command = command + f"pmctl init source {source}\n"
+                    # Since this variable came later, default to the source name if it doesn't exist
+                    desc = self.config['vi'][str(i)].get('desc', source)
+                    command = command + f"pmctl init source {source} {desc}\n"
         return command
 
     def start_eqs(self):
@@ -294,18 +298,20 @@ class Pulse:
             volume = pulsectl.PulseVolumeInfo(val / 100, 2)
             self.pulsectl.source_output_volume_set(index, volume)
 
-    def rename(self, device_index, new_name):
-        old_name = self.config[device_index[0]][device_index[1]]['name']
-        if new_name == old_name:
+    def rename(self, device_index, new_desc):
+        name = self.config[device_index[0]][device_index[1]]['name']
+        # Since this variable came later, default to the source name if it doesn't exist
+        old_desc = self.config[device_index[0]][device_index[1]].get('desc', name)
+        if new_desc == old_desc:
             return False
 
-        if old_name != '':
-            command = f'pmctl remove {old_name}'
+        if name != '':
+            command = f'pmctl remove {name}'
             os.popen(command)
 
-        self.config[device_index[0]][device_index[1]]['name'] = new_name
-        if new_name != '':
-            command = f'pmctl init sink {new_name}\n'
+        self.config[device_index[0]][device_index[1]]['desc'] = new_desc
+        if new_desc != '':
+            command = f'pmctl init sink {name} {new_desc}\n'
             command = command + self.reconnect(device_index[0], device_index[1], 'init')
             command = command + self.set_primary(device_index, 'init')
             os.popen(command)

--- a/pulsemeeter/config.json
+++ b/pulsemeeter/config.json
@@ -28,6 +28,7 @@
 	"b": {
 		"1": {
 			"name": "Virtual_Output_B1",
+			"desc": "Virtual_Output_B1",
 			"primary": false,
 			"vol": 100,
 			"mute": false,
@@ -37,6 +38,7 @@
 		},
 		"2": {
 			"name": "Virtual_Output_B2",
+			"desc": "Virtual_Output_B2",
 			"primary": false,
 			"vol": 100,
 			"mute": false,
@@ -46,6 +48,7 @@
 		},
 		"3": {
 			"name": "Virtual_Output_B3",
+			"desc": "Virtual_Output_B3",
 			"primary": false,
 			"vol": 100,
 			"mute": false,
@@ -57,6 +60,7 @@
 	"vi": {
 		"1": {
 			"name": "Virtual_Input_1",
+			"desc": "Virtual_Input_1",
 			"primary": false,
 			"a1": false,
 			"a2": false,
@@ -79,6 +83,7 @@
 		},
 		"2": {
 			"name": "Virtual_Input_2",
+			"desc": "Virtual_Input_2",
 			"primary": false,
 			"a1": false,
 			"a2": false,
@@ -101,6 +106,7 @@
 		},
 		"3": {
 			"name": "Virtual_Input_3",
+			"desc": "Virtual_Input_3",
 			"primary": false,
 			"a1": false,
 			"a2": false,

--- a/scripts/pmctl
+++ b/scripts/pmctl
@@ -184,7 +184,7 @@ list_sink_inputs (){
 	# turn sink number into name
 	sinks=$(echo "$apps" | grep Sink:)
 	for sink in $sinks; do
-		name=$(LC_ALL=C pactl list sinks | grep -A 2 "\#$(echo $sink | sed "s/Sink://g")$" | awk '/Name/ {print $2}')
+		name=$(LC_ALL=C pactl list sinks | grep -A 3 "\#$(echo $sink | sed "s/Sink://g")$" | awk '/Description/ {print $2}')
 		apps=$(echo "$apps" | sed "s/$sink$/\"device\":\"$name\"/")
 	done
 

--- a/scripts/pmctl
+++ b/scripts/pmctl
@@ -4,17 +4,19 @@ init (){
 	case $1 in
 		"sink")
 			sink=$2
+			description=$3
 			pactl list sinks short | grep $sink && exit
-			pactl load-module module-null-sink sink_name=$sink sink_properties="device.description="$sink""
+			pactl load-module module-null-sink sink_name=$sink sink_properties="device.description="$description""
 		;;
 		"source")
 			source=$2
+			description=$3
 			pactl list sources short | grep $source && exit
 			pactl load-module module-null-sink sink_name=$source"_sink" # sink_properties=device.description=$source"_sink"
 			if which pulseaudio 2>/dev/null 1>&2; then
-				pactl load-module module-remap-source source_name=$source master=$source"_sink.monitor" source_properties=device.description=$source 
+				pactl load-module module-remap-source source_name=$source master=$source"_sink.monitor" source_properties=device.description=$description 
 			else
-				pactl load-module module-remap-source source_name=$source master=$source"_sink" source_properties=device.description=$source 
+				pactl load-module module-remap-source source_name=$source master=$source"_sink" source_properties=device.description=$description 
 			fi
 		;;
 	esac
@@ -123,7 +125,7 @@ list (){
 	# turn into json
 	list=$(echo "$list" | sed ':a $!N;s/\n/, /;ta P;D;' |\
 		sed ':a $!N;s/#/\n{"id":/;ta P;D;' |\
-		sed '/^$/d; s/ 	/ /g; s/Description/"description"/g; s/Volume:"/"volume":/g; s/%"//g; s/Name/"name"/g; s/$/}/; s/, }/}/' |\
+		sed '/^$/d; s/  / /g; s/Description/"description"/g; s/Volume:"/"volume":/g; s/%"//g; s/Name/"name"/g; s/$/}/; s/, }/}/' |\
 		grep -vwE Monitor | grep -vwE null | grep -vwE remap-source | grep -vwE module-remap-source | grep -vwE ladspa)
 
 	printf "%s" "$list"
@@ -372,7 +374,7 @@ fi
 
 case $1 in
 	"init")
-		init $2 $3
+		init $2 $3 $4
 	;;
 
 	"connect") 
@@ -396,7 +398,7 @@ case $1 in
 	;;
 
 	"rename")
-		rename $2 $3
+		rename $2 $3 $4
 	;;
 
 	"mute")


### PR DESCRIPTION
### Why
This change restructures how devices are renamed and updated. This is done to help be able to easily identify which devices were created by Pulsemeeter and which ones may be user created.

I actually discovered this limitation when trying to make my own sink that uses a null module, but I was unable to load the null module as a sink in Pulsemeeter. This doesn't fixing not being able to load external null modules, but it's a step that helps make it easier to maintain and I think allows for easier managing of devices.

### How it works
Previously, the config file had one `name` field that was used for the name and the description of the device. Now, each device has both a `name` and a `desc` field. When a user does any type of renaming, the device is referenced by the name (which now never changes) and the description property is updated.

For backwards compatibility, if a user is using an old config that doesn't have a `desc` field for the device, it will default to the `name` field, and then also create the the `desc` field as necessary.

I didn't see a contributing guideline, so please let me know if there's anything else I should include.
