### PR TITLE
fixed naming of tabs hardware inputs and virtual inputs

### DIFF
--- a/pulsemeeter/interface/layouts/tabbed.glade
+++ b/pulsemeeter/interface/layouts/tabbed.glade
@@ -2412,7 +2412,7 @@ KHz</property>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Virtual Inputs</property>
+                <property name="label" translatable="yes">Hardware Inputs</property>
               </object>
               <packing>
                 <property name="position">4</property>
@@ -3295,7 +3295,7 @@ KHz</property>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Hardware Inputs</property>
+                <property name="label" translatable="yes">Virtual Inputs</property>
               </object>
               <packing>
                 <property name="position">4</property>


### PR DESCRIPTION
# Description

Small fix to the tab names in the tabbed layout, the tab containing microphones etc. was named "Virtual Inputs" and the tab containing the .. virtual inputs was named "hardware inputs." i simply switched the labels.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

installing from source directly with sudo pip install . , before the change the tab names were wrong, then reinstalling after the change the tabs were named correctly.


# Checklist : 
You don't need to do all of this, but at least check what you did
- [x] My changes generate no new warnings
very tiny change.
