### PR TITLE
regular pull into nightly (bug fixes)

### DIFF
--- a/pulsemeeter/backends/pmctl.py
+++ b/pulsemeeter/backends/pmctl.py
@@ -100,6 +100,9 @@ def list(device_type, device_name=None):
 def get_ports(device, device_type):
     return cmd(f'pmctl get-ports {device_type} {device}').split('\n')
 
+def get_pactl_version():
+    return cmd('pmctl get-pactl-version')
+
 
 def subscribe():
     command = ['pactl', 'subscribe']

--- a/pulsemeeter/config.json
+++ b/pulsemeeter/config.json
@@ -6,7 +6,8 @@
 			"mute": false,
 			"eq_control": "",
 			"eq_name": "",
-			"use_eq": false
+			"use_eq": false,
+			"channels": 1
 		},
 		"2": {
 			"name": "",
@@ -14,7 +15,8 @@
 			"mute": false,
 			"eq_control": "",
 			"eq_name": "",
-			"use_eq": false
+			"use_eq": false,
+			"channels": 1
 		},
 		"3": {
 			"name": "",
@@ -22,7 +24,8 @@
 			"mute": false,
 			"eq_control": "",
 			"eq_name": "",
-			"use_eq": false
+			"use_eq": false,
+			"channels": 1
 		}
 	},
 	"b": {

--- a/pulsemeeter/socket/client.py
+++ b/pulsemeeter/socket/client.py
@@ -540,7 +540,7 @@ class Client:
         devices[v] = []
 
         for i in devl:
-            if pmctl.get_pactl_version < 16:
+            if pmctl.get_pactl_version() < 16:
                 # LEGACY
                 if 'properties' not in i or 'alsa.card_name' in i['properties']:
                     devices[h].append(i)

--- a/pulsemeeter/socket/client.py
+++ b/pulsemeeter/socket/client.py
@@ -540,11 +540,18 @@ class Client:
         devices[v] = []
 
         for i in devl:
-            # if 'properties' not in i or 'alsa.card_name' in i['properties']:
-            if 'HARDWARE' in i['flags']:
-                devices[h].append(i)
+            if pmctl.get_pactl_version < 16:
+                # LEGACY
+                if 'properties' not in i or 'alsa.card_name' in i['properties']:
+                    devices[h].append(i)
+                else:
+                    devices[v].append(i)
             else:
-                devices[v].append(i)
+                # PROPER CHECK
+                if 'HARDWARE' in i['flags']:
+                    devices[h].append(i)
+                else:
+                    devices[v].append(i)
 
         if hardware is True:
             return devices[h]

--- a/scripts/pmctl
+++ b/scripts/pmctl
@@ -190,6 +190,11 @@ move_source_output () {
 	pactl move-source-output $app $master
 }
 
+get_pactl_version () {
+	version=$(pactl --version | grep pactl | sed 's/.* //; s/\..*//')
+	printf "%d" "$version"
+}
+
 list (){
 
 	local device_type=$1
@@ -634,6 +639,10 @@ case $1 in
 
 	"get-ports")
 		get_ports $2 $3
+	;;
+
+	"get-pactl-version")
+		get_pactl_version
 	;;
 
 	"*") echo "command not found";;


### PR DESCRIPTION
## Description

Just some bug fixes and additions to pmctl.

## related errors:

config not loading
```
[ERROR] in [server]: Traceback (most recent call last):
  File "/home/flz/.local/lib/python3.10/site-packages/pulsemeeter/socket/server.py", line 318, in handle_command
    ret_msg = function(*args)
  File "/home/flz/.local/lib/python3.10/site-packages/pulsemeeter/backends/manager.py", line 487, in connect
    oselports = list(range(sink_config['channels']))
KeyError: 'channels'
```

pactl < 16 not working
```
pulsemeeter
Traceback (most recent call last):
  File "/usr/local/bin/pulsemeeter", line 33, in <module>
    sys.exit(load_entry_point('pulsemeeter==1.2.16', 'console_scripts', 'pulsemeeter')())
  File "/usr/local/lib/python3.10/site-packages/pulsemeeter/__main__.py", line 554, in main
    start_app(isserver, trayonly)
  File "/usr/local/lib/python3.10/site-packages/pulsemeeter/__main__.py", line 483, in start_app
    MainWindow(isserver=isserver, trayonly=trayonly)
  File "/usr/local/lib/python3.10/site-packages/pulsemeeter/interface/main_window.py", line 49, in __init__
    self.windowinstance = self.start_window(isserver)
  File "/usr/local/lib/python3.10/site-packages/pulsemeeter/interface/main_window.py", line 97, in start_window
    sources = self.client.list('sources')
  File "/usr/local/lib/python3.10/site-packages/pulsemeeter/socket/client.py", line 544, in list
    if 'HARDWARE' in i['flags']:
KeyError: 'flags'
 ```