### PR TITLE
Port to AyatanaAppindicator3

### DIFF
--- a/pulsemeeter/interface/main_window.py
+++ b/pulsemeeter/interface/main_window.py
@@ -20,8 +20,9 @@ from gi import require_version as gi_require_version
 
 # from pulsectl import Pulse
 gi_require_version('Gtk', '3.0')
-gi_require_version('AppIndicator3', '0.1')
-from gi.repository import Gtk, GLib, AppIndicator3
+gi_require_version('AyatanaAppIndicator3', '0.1')
+from gi.repository import Gtk, GLib
+from gi.repository import AyatanaAppIndicator3 as AppIndicator3
 
 
 class MainWindow(Gtk.Window):


### PR DESCRIPTION
# Description

I am using Mageia Cauldron and it doesn't have AppIndicator3, but instead uses Ayatana.

Am running it now and it works as expected.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update

# How Has This Been Tested?

Before doing this I had to "disable" the trayicon to get pulsemeeter running. Now I have the trayicon and the app working.

- [ ] Test A
- [ ] Test B


# Checklist : 
You don't need to do all of this, but at least check what you did
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
