### PR TITLE
This fixes the message "grep: warning: stray \ before #"

### DIFF
--- a/scripts/pmctl
+++ b/scripts/pmctl
@@ -351,7 +351,7 @@ list_sink_inputs (){
 	# turn sink number into name
 	sinks=$(echo "$apps" | grep Sink:)
 	for sink in $sinks; do
-		name=$(LC_ALL=C pactl list sinks | grep -A 2 "\#$(echo $sink | sed "s/Sink://g")$" | awk '/Name/ {print $2}')
+		name=$(LC_ALL=C pactl list sinks | grep -A 2 "#$(echo $sink | sed "s/Sink://g")$" | awk '/Name/ {print $2}')
 		apps=$(echo "$apps" | sed "s/$sink$/\"device\":\"$name\"/")
 	done
 


### PR DESCRIPTION
Before this fix, the main window did not show any Virtual Outputs.

After the change, it shows the correct Outputs.

It also eliminates the following messages from command line.

```
ERROR: invalid json grep: warning: stray \ before #
grep: warning: stray \ before #
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist : 
You don't need to do all of this, but at least check what you did
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
