### PR TITLE
Port to AyatanaAppindicator3 with backwards compatability for Appindi…

### DIFF
--- a/pulsemeeter/interface/main_window.py
+++ b/pulsemeeter/interface/main_window.py
@@ -19,10 +19,14 @@ from ..socket import Client
 from gi import require_version as gi_require_version
 
 # from pulsectl import Pulse
-gi_require_version('Gtk', '3.0')
-gi_require_version('AppIndicator3', '0.1')
-from gi.repository import Gtk, GLib, AppIndicator3
-
+try:
+    gi_require_version('Gtk', '3.0')
+    gi_require_version('AppIndicator3', '0.1')
+    from gi.repository import Gtk, GLib, AppIndicator3
+except ValueError:
+    gi_require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import Gtk, GLib
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
 
 class MainWindow(Gtk.Window):
 


### PR DESCRIPTION
…cator3

# Description

Experienced issues with getting this working on Debian 11 as appindicator has been depreciated for ayatanaappindicator 

Similar change to [This pull request](https://github.com/theRealCarneiro/pulsemeeter/pull/105) with the exception that the program is now backwards compatible with AppIndicator3

New dependencies for AyatanaAppIndicator3
gir1.2-ayatanaappindicator3-0.1

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Installed the changed version of the package from source 
- [x] Validated it functions as expected


# Checklist : 
You don't need to do all of this, but at least check what you did
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
