### PR TITLE
use AyatanaAppIndicator3 if available, fallback to AppIndicator3

### DIFF
--- a/pulsemeeter/interface/main_window.py
+++ b/pulsemeeter/interface/main_window.py
@@ -20,8 +20,7 @@ from gi import require_version as gi_require_version
 
 # from pulsectl import Pulse
 gi_require_version('Gtk', '3.0')
-gi_require_version('AppIndicator3', '0.1')
-from gi.repository import Gtk, GLib, AppIndicator3
+from gi.repository import Gtk, GLib
 
 
 class MainWindow(Gtk.Window):
@@ -699,6 +698,18 @@ class MainWindow(Gtk.Window):
         return menu
 
     def create_indicator(self):
+        # Try AyatanaAppIndicator3 first, fall back to AppIndicator3
+        try:
+            gi_require_version('AyatanaAppIndicator3', '0.1')
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+        except (ImportError, ValueError):
+            try:
+                gi_require_version('AppIndicator3', '0.1')
+                from gi.repository import AppIndicator3 as AppIndicator3
+            except (ImportError, ValueError):
+                print("Neither AyatanaAppIndicator3 nor AppIndicator3 found. System tray functionality will be disabled.")
+                return None
+
         indicator = AppIndicator3.Indicator.new(id='pulsemeetertray',
                 icon_name='Pulsemeeter',
                 category=AppIndicator3.IndicatorCategory.APPLICATION_STATUS)


### PR DESCRIPTION
# Description

Debian has transitioned to Ayatana Indicators:
https://wiki.debian.org/Ayatana/IndicatorsTransition

This allows pulsemeeter to support both libraries, so it can run on newer debian systems using default apt packages.

Fixes #66 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (in the wiki)

> In some newer distrobutions you may have to install this package ([#66](https://github.com/theRealCarneiro/pulsemeeter/issues/66)):
gir1.2-ayatanaappindicator3-0.1
```
sudo apt install gir1.2-appindicator3-0.1 gir1.2-ayatanaappindicator3-0.1
```

# How Has This Been Tested?

Pulsemeeter is able to launch on Debian 12 with only standard system packages installed. I am unable to test falling back to the legacy AppIndicator3 library provided by `gir1.2-appindicator3-0.1`.

- Debian 12.7
- Linux 6.1.0-26-amd64
- Python 3.11.2

# Checklist : 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~Any dependent changes have been merged and published in downstream modules~
