### PR TITLE
Remove dead code causing asyncio error with latest Python 3.14+

### DIFF
--- a/src/pulsemeeter/scripts/pmctl_async.py
+++ b/src/pulsemeeter/scripts/pmctl_async.py
@@ -6,11 +6,6 @@ import pulsectl_asyncio
 from pulsemeeter.model.types import PulseEvent
 
 LOG = logging.getLogger('generic')
-# PULSE = pulsectl.Pulse('pmctl')
-
-# TODO: Use a single PulseAsync object
-
-PULSE = pulsectl_asyncio.PulseAsync('pmctl_async')
 
 
 async def init(device_type: str, device_name: str, channel_num: int = 2):


### PR DESCRIPTION
# Description

Fixes crash on startup `RuntimeError: There is no current event loop in thread 'MainThread'.` when running with Python 3.14.

Removes pulsectl_asyncio.PulseAsync() call which relies upon asyncio.get_event_loop() which has now been deprecated in Python 3.14 and results in an error now (see https://github.com/python/cpython/issues/93453). Code is unused so we can just drop it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Basic Usage - Open without error

# Checklist : 

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
