### PR TITLE
Fix taskbar window-to-launcher association in KDE

### DIFF
--- a/share/applications/pulsemeeter.desktop
+++ b/share/applications/pulsemeeter.desktop
@@ -4,4 +4,5 @@ Name=Pulsemeeter
 GenericName=Audio Mixer
 Icon=Pulsemeeter
 Exec=pulsemeeter
+StartupWMClass=org.pulsemeeter.pulsemeeter
 Categories=Audio;AudioVideo;Midi;X-Alsa;X-Jack;X-AudioEditing;


### PR DESCRIPTION
# Description

Rename desktop file to match GTK application_id so KDE can associate the window with its desktop entry
Add StartupWMClass as fallback for other desktop environments

Fixes: 
[Screencast_20260209_152141.webm](https://github.com/user-attachments/assets/2cd0673a-86ff-4b65-80af-dde2a4e6a427)
Into:
[Screencast_20260209_153501.webm](https://github.com/user-attachments/assets/a043b8e8-f512-4474-96bc-af93bcfb2bac)

Unfortunately, since this is _the_ .desktop file users would see their pin become orphaned and would require re-pinning and if there were any user specific changed settings in the .desktop file they'd need to be remade. Alternatively, we could only add the StartupWMClass change and this would _probably_ be good enough for most WMs (KDE & Gnome) but renaming it more the "correct" freedesktop fix.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Basic Usage

# Checklist : 
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
