### PR TITLE
Fix pulsemeeter init (Proper initialization of devices)

### DIFF
--- a/src/pulsemeeter/main.py
+++ b/src/pulsemeeter/main.py
@@ -20,7 +20,9 @@ def start_gui():
 
 
 def init_devices():
-    ConfigModel.load_config()
+    config_persistence = ConfigPersistence(ConfigModel, CONFIG_FILE)
+    device_repository = DeviceRepository(config_persistence)
+    DeviceController(device_repository=device_repository)
 
 
 def cleanup_devices():


### PR DESCRIPTION
# Description

Update init_devices() to properly load config & initialize devices to audio server

Fixes #167 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Blank Config -> pulsemeeter init
- [X] Set Config in GUI & cleanup -> pulsemeeter init -> Devices Appear -> cleanup & init -> Devices from config reappear

# Checklist : 
You don't need to do all of this, but at least check what you did
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
