### PR TITLE
FEAT: Per route volume

### DIFF
--- a/src/pulsemeeter/clients/gtk/gtk_client.py
+++ b/src/pulsemeeter/clients/gtk/gtk_client.py
@@ -141,6 +141,8 @@ class GtkClient(Gtk.Application):
             'mute': self.device_controller.set_mute,
             'primary': self.device_controller.set_primary,
             'connect': self.device_controller.set_connection,
+            'route_volume': self.device_controller.set_route_volume,
+            'use_loopback': self.device_controller.set_use_loopback,
             'connection_change': self.device_controller.update_connection,
             'device_new': self.device_controller.create_device,
             'device_remove': self.device_controller.remove_device,

--- a/src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py
@@ -11,42 +11,103 @@ from gi.repository import Gtk, GObject  # noqa: E402
 _ = gettext.gettext
 
 
-class ConnectionWidget(Gtk.ToggleButton):
+class ConnectionWidget(Gtk.Box):
 
     __gsignals__ = {
         'connection': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (bool,)),
+        'route_volume': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (int,)),
+        'use_loopback': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (bool,)),
         'settings_pressed': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, ()),
     }
 
     def __init__(self, label: str, connection_model, *args, **kwargs):
-        super().__init__(label=label, active=connection_model.state, *args, **kwargs)
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=4, *args, **kwargs)
+        self.set_hexpand(True)
         self.connection_model = connection_model
-        self._signal_handler_id = self.connect('toggled', self._on_toggled)
+
+        # Toggle button (existing connection toggle)
+        self.toggle_button = Gtk.ToggleButton(label=label, active=connection_model.state)
+        self.toggle_button.set_size_request(120, -1)
+        self._toggle_handler_id = self.toggle_button.connect('toggled', self._on_toggled)
+
+        # Right-click gesture for connection settings popup
         gesture = Gtk.GestureClick.new()
         gesture.set_button(3)
         gesture.connect("pressed", self._on_pressed)
         self.popover = ConnectionSettingsPopup(connection_model)
-        self.popover.set_parent(self)
-        self.add_controller(gesture)
+        self.popover.set_parent(self.toggle_button)
+        self.toggle_button.add_controller(gesture)
+
+        # Checkbox for use_loopback opt-in
+        self.loopback_check = Gtk.CheckButton(active=connection_model.use_loopback)
+        self.loopback_check.set_tooltip_text(_('Enable per-route volume (uses pw-loopback)'))
+        self._loopback_handler_id = self.loopback_check.connect('toggled', self._on_loopback_toggled)
+
+        # Volume slider for route volume
+        self.volume_scale = Gtk.Scale(orientation=Gtk.Orientation.HORIZONTAL)
+        self.volume_scale.set_range(0, 153)
+        self.volume_scale.set_increments(1, 5)
+        self.volume_scale.set_digits(0)
+        self.volume_scale.set_value(connection_model.route_volume)
+        self.volume_scale.set_hexpand(True)
+        self.volume_scale.set_size_request(150, 0)
+        self.volume_scale.add_mark(100, Gtk.PositionType.TOP, '')
+        self.volume_scale.set_tooltip_text(_('Route volume'))
+        self._volume_handler_id = self.volume_scale.connect('value-changed', self._on_volume_changed)
+
+        # Pack widgets
+        self.append(self.toggle_button)
+        self.append(self.loopback_check)
+        self.append(self.volume_scale)
+
+        # Initial visibility
+        self._update_visibility()
         self.set_accessible()
 
     def set_accessible(self):
         description_label = _('Connect to %s, right click to open connection settings') % self.connection_model.nick
-        self.set_tooltip_text(description_label)
-        Gtk.Accessible.update_property(self, [Gtk.AccessibleProperty.DESCRIPTION], [description_label])
-        Gtk.Accessible.update_property(self, [Gtk.AccessibleProperty.HAS_POPUP], [True])
+        self.toggle_button.set_tooltip_text(description_label)
+        Gtk.Accessible.update_property(self.toggle_button, [Gtk.AccessibleProperty.DESCRIPTION], [description_label])
+        Gtk.Accessible.update_property(self.toggle_button, [Gtk.AccessibleProperty.HAS_POPUP], [True])
+
+    def _update_visibility(self):
+        '''Update visibility of checkbox and slider based on connection state and loopback flag.'''
+        is_connected = self.toggle_button.get_active()
+        use_loopback = self.loopback_check.get_active()
+        self.loopback_check.set_visible(is_connected)
+        self.volume_scale.set_visible(is_connected and use_loopback)
 
     def _on_toggled(self, widget):
+        self._update_visibility()
         self.emit('connection', widget.get_active())
+
+    def _on_loopback_toggled(self, widget):
+        self._update_visibility()
+        self.emit('use_loopback', widget.get_active())
+
+    def _on_volume_changed(self, widget):
+        self.emit('route_volume', int(widget.get_value()))
 
     def _on_pressed(self, _, __, ___, ____):
         self.popover.popup()
         self.emit('settings_pressed')
 
     def set_connection(self, state):
-        self.handler_block(self._signal_handler_id)
-        self.set_active(state)
-        self.handler_unblock(self._signal_handler_id)
+        self.toggle_button.handler_block(self._toggle_handler_id)
+        self.toggle_button.set_active(state)
+        self._update_visibility()
+        self.toggle_button.handler_unblock(self._toggle_handler_id)
 
     def get_connection(self):
-        return self.get_active()
+        return self.toggle_button.get_active()
+
+    def set_route_volume(self, value):
+        self.volume_scale.handler_block(self._volume_handler_id)
+        self.volume_scale.set_value(value)
+        self.volume_scale.handler_unblock(self._volume_handler_id)
+
+    def set_use_loopback(self, state):
+        self.loopback_check.handler_block(self._loopback_handler_id)
+        self.loopback_check.set_active(state)
+        self._update_visibility()
+        self.loopback_check.handler_unblock(self._loopback_handler_id)

--- a/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
@@ -38,6 +38,8 @@ class DeviceWidget(Gtk.Frame):
         'device_remove': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, ()),
         'device_change': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT,)),
         'connection': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (str, str, bool)),
+        'route_volume': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (str, str, int)),
+        'use_loopback': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (str, str, bool)),
         'update_connection': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (str, str, GObject.TYPE_PYOBJECT)),
         'settings_pressed': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (GObject.TYPE_PYOBJECT,)),
         'connection_settings_pressed': (GObject.SIGNAL_RUN_FIRST, GObject.TYPE_NONE, (str, str))
@@ -131,6 +133,8 @@ class DeviceWidget(Gtk.Frame):
                 button = ConnectionWidget(connection_schema.nick, connection_schema)
                 self.connections_widgets[output_type].add_widget(output_id, button)
                 button.connect('connection', self._on_connection_change, output_type, output_id)
+                button.connect('route_volume', self._on_route_volume, output_type, output_id)
+                button.connect('use_loopback', self._on_use_loopback, output_type, output_id)
                 button.connect('settings_pressed', self._on_connection_edit_pressed, output_type, output_id)
                 button.popover.confirm_button.connect('clicked', self._on_connection_settings_save, output_type, output_id)
 
@@ -153,6 +157,12 @@ class DeviceWidget(Gtk.Frame):
 
     def _on_connection_change(self, _, state, output_type, output_id):
         self.emit('connection', output_type, output_id, state)
+
+    def _on_route_volume(self, _, volume, output_type, output_id):
+        self.emit('route_volume', output_type, output_id, volume)
+
+    def _on_use_loopback(self, _, state, output_type, output_id):
+        self.emit('use_loopback', output_type, output_id, state)
 
     def _on_mute_change(self, _, state):
         self.emit('mute', state)

--- a/src/pulsemeeter/controller/device_controller.py
+++ b/src/pulsemeeter/controller/device_controller.py
@@ -1,5 +1,6 @@
 import sys
 import logging
+import threading
 
 from pydantic import PrivateAttr
 from pulsemeeter.scripts import pmctl
@@ -38,6 +39,8 @@ class DeviceController(SignalModel):
         '''
         super().__init__()
 
+        self._loopback_procs = {}
+        self._intermediate_sinks = {}
         self.device_repository = device_repository
         if not pmctl.is_pipewire():
             LOG.error('ERROR: pipewire-pulse not detected, pipewire-pulse is required')
@@ -151,8 +154,21 @@ class DeviceController(SignalModel):
 
     def cleanup(self):
         '''
-        Removes all pulse devices from pulse.
+        Removes all pulse devices from pulse and terminates loopback processes.
         '''
+        # Terminate all loopback processes
+        for proc in self._loopback_procs.values():
+            pmctl.destroy_loopback(proc)
+        self._loopback_procs.clear()
+
+        # Remove all intermediate sinks
+        for sink_name in self._intermediate_sinks.values():
+            try:
+                pmctl.remove_device(sink_name)
+            except RuntimeError:
+                LOG.warning('Failed to remove intermediate sink %s during cleanup', sink_name)
+        self._intermediate_sinks.clear()
+
         device_dict = self.device_repository.get_all_devices()
         for _, device_list in device_dict.items():
             for _, device in device_list.items():
@@ -214,6 +230,7 @@ class DeviceController(SignalModel):
     def set_connection(self, input_type, input_id, output_type, output_id, state: bool = None, soft=False):
         '''
         Set the connection state between two devices.
+        Uses pw-loopback when use_loopback is enabled, otherwise uses direct pw-link.
         Args:
             input_type (str): Input device type.
             input_id (str): Input device identifier.
@@ -234,14 +251,153 @@ class DeviceController(SignalModel):
             input_device.set_connection(output_type, output_id, state, emit=False)
             self.emit('connect', input_type, input_id, output_type, output_id, state)
 
+        loopback_name = pmctl.make_loopback_name(input_device.name, output_device.name)
+
+        # Skip PA operations if either device is disconnected
+        if state and not self._device_available(input_device):
+            LOG.warning('Input device unavailable, skipping connection: %s', input_device.name)
+            return
+        if state and not self._device_available(output_device):
+            LOG.warning('Output device unavailable, skipping connection: %s', output_device.name)
+            return
+
+        if connection_model.use_loopback:
+            self._set_loopback_connection(
+                loopback_name, input_device, output_device, connection_model, state
+            )
+        else:
+            self._set_link_connection(input_device, output_device, connection_model, state)
+            self._teardown_loopback(loopback_name, output_device)
+
+    def _device_available(self, device):
+        '''Check device presence via pw-link subprocess.'''
+        port_type = 'output' if device.device_type == 'source' else 'input'
+        try:
+            return len(pmctl.get_ports(port_type, device.name)) > 0
+        except RuntimeError:
+            return False
+
+    def _set_link_connection(self, input_device, output_device, connection_model, state):
+        '''Direct pw-link connection.'''
         input_sel_channels = input_device.get_selected_channel_list()
         output_sel_channels = output_device.get_selected_channel_list()
         port_map = connection_model.str_port_map(input_sel_channels, output_sel_channels)
-
         try:
             pmctl.link_channels(input_device.name, output_device.name, port_map, state)
         except RuntimeError:
             LOG.error("Device ports not found, device probably disconnected")
+
+    def _set_loopback_connection(self, loopback_name, input_device, output_device, connection_model, state):
+        '''pw-loopback connection for per-route volume control.'''
+        is_b_type = output_device.device_type == 'source'
+
+        if state:
+            # If a loopback with this name already exists (e.g. app restarted without cleanup), adopt it
+            if pmctl.loopback_exists(loopback_name):
+                LOG.debug('Loopback %s already exists, adopting', loopback_name)
+                pmctl.set_route_volume(loopback_name, connection_model.route_volume)
+                return
+
+            self._teardown_loopback(loopback_name, output_device)
+
+            try:
+                capture_serial = pmctl.get_device_serial(input_device.device_type, input_device.name)
+                channels = min(input_device.channels, output_device.channels)
+
+                if is_b_type:
+                    # B-type: loopback → intermediate sink → pw-link monitor → virtual output
+                    temp_sink_name = pmctl.create_intermediate_sink(
+                        loopback_name, channels, output_device.channel_list
+                    )
+                    self._intermediate_sinks[loopback_name] = temp_sink_name
+                    if not pmctl.wait_for_device('sink', temp_sink_name):
+                        LOG.warning('Intermediate sink %s did not appear in time', temp_sink_name)
+                    playback_serial = pmctl.get_device_serial('sink', temp_sink_name)
+                else:
+                    # A-type: direct loopback to output sink
+                    playback_serial = pmctl.get_device_serial(output_device.device_type, output_device.name)
+
+                proc = pmctl.create_loopback(
+                    name=loopback_name,
+                    capture_serial=capture_serial,
+                    playback_serial=playback_serial,
+                    channels=channels,
+                )
+                self._loopback_procs[loopback_name] = proc
+
+                # Wait for loopback in background thread to avoid blocking GTK main thread
+                volume = connection_model.route_volume
+                output_name = output_device.name
+                def _wait_and_set_volume():
+                    if pmctl.wait_for_loopback(loopback_name):
+                        if is_b_type:
+                            # Link the bridge sink's monitor outputs to the virtual output's inputs
+                            LOG.debug('Linking bridge %s → virtual output %s', temp_sink_name, output_name)
+                            pmctl.link(temp_sink_name, output_name)
+                        pmctl.set_route_volume(loopback_name, volume)
+                    else:
+                        LOG.warning('Loopback %s did not appear in time', loopback_name)
+                threading.Thread(target=_wait_and_set_volume, daemon=True).start()
+            except Exception:
+                LOG.error('Failed to create loopback %s, device probably disconnected', loopback_name)
+        else:
+            self._teardown_loopback(loopback_name, output_device)
+
+    def _teardown_loopback(self, loopback_name, output_device):
+        '''Destroy loopback process and clean up intermediate sink if they exist.'''
+        if loopback_name in self._loopback_procs:
+            pmctl.destroy_loopback(self._loopback_procs.pop(loopback_name))
+        temp_sink_name = self._intermediate_sinks.pop(loopback_name, None)
+        if temp_sink_name:
+            pmctl.link(temp_sink_name, output_device.name, state=False)
+            pmctl.remove_intermediate_sink(loopback_name)
+
+    def set_route_volume(self, input_type, input_id, output_type, output_id, volume):
+        '''Set per-route volume for a loopback connection.'''
+        input_device = self.device_repository.get_device(input_type, input_id)
+        output_device = self.device_repository.get_device(output_type, output_id)
+        connection_model = input_device.connections[output_type][output_id]
+        connection_model.route_volume = volume
+
+        loopback_name = pmctl.make_loopback_name(input_device.name, output_device.name)
+        if connection_model.state and connection_model.use_loopback:
+            pmctl.set_route_volume(loopback_name, volume)
+
+        self.emit('route_volume', input_type, input_id, output_type, output_id, volume)
+
+    def set_use_loopback(self, input_type, input_id, output_type, output_id, state):
+        '''Toggle use_loopback for a connection. If active, reconnects with the new method.'''
+        input_device = self.device_repository.get_device(input_type, input_id)
+        output_device = self.device_repository.get_device(output_type, output_id)
+        connection_model = input_device.connections[output_type][output_id]
+
+        was_connected = connection_model.state
+        old_use_loopback = connection_model.use_loopback
+
+        if state == old_use_loopback:
+            return
+
+        loopback_name = pmctl.make_loopback_name(input_device.name, output_device.name)
+
+        # Skip PA operations if either device is disconnected
+        devices_available = self._device_available(input_device) and self._device_available(output_device)
+
+        # If connection is active, disconnect with old method, flip, reconnect with new
+        if was_connected and devices_available:
+            if old_use_loopback:
+                self._set_loopback_connection(loopback_name, input_device, output_device, connection_model, False)
+            else:
+                self._set_link_connection(input_device, output_device, connection_model, False)
+
+        connection_model.use_loopback = state
+
+        if was_connected and devices_available:
+            if state:
+                self._set_loopback_connection(loopback_name, input_device, output_device, connection_model, True)
+            else:
+                self._set_link_connection(input_device, output_device, connection_model, True)
+
+        self.emit('use_loopback', input_type, input_id, output_type, output_id, state)
 
     def update_connection(self, input_type, input_id, output_type, output_id, connection_model):
         '''

--- a/src/pulsemeeter/controller/event_controller.py
+++ b/src/pulsemeeter/controller/event_controller.py
@@ -154,7 +154,10 @@ class EventController(SignalModel):
         Args:
             event: The event object.
         '''
-        pa_device = await pmctl_async.get_device_by_id(event.facility, event.index)
+        try:
+            pa_device = await pmctl_async.get_device_by_id(event.facility, event.index)
+        except pulsectl.pulsectl.PulseIndexError:
+            return
         pm_device_types = ('hi', 'b') if event.facility == 'source' else ('vi', 'a')
         device_search = self.device_repository.find_device_by_key
         search_res = device_search('name', pa_device.name, pm_device_types)

--- a/src/pulsemeeter/controller/gtk_controller.py
+++ b/src/pulsemeeter/controller/gtk_controller.py
@@ -362,6 +362,8 @@ class GtkController(SignalModel):
             'volume': self.set_volume,
             'mute': self.set_mute,
             'connection': self.set_connection,
+            'route_volume': self.set_route_volume,
+            'use_loopback': self.set_use_loopback,
             'primary': self.set_primary,
             'device_change': self.update_device_model,
             'device_remove': self.device_remove,
@@ -521,6 +523,18 @@ class GtkController(SignalModel):
         Call to device model to set model connection
         '''
         self.emit('connect', input_type, input_id, output_type, output_id, state)
+
+    def set_route_volume(self, _, output_type, output_id, volume: int, input_type, input_id):
+        '''
+        Relay per-route volume change to device controller
+        '''
+        self.emit('route_volume', input_type, input_id, output_type, output_id, volume)
+
+    def set_use_loopback(self, _, output_type, output_id, state: bool, input_type, input_id):
+        '''
+        Relay use_loopback toggle to device controller
+        '''
+        self.emit('use_loopback', input_type, input_id, output_type, output_id, state)
 
     def update_connection(self, _, output_type, output_id, connection_model, input_type, input_id):
         '''

--- a/src/pulsemeeter/model/config_model.py
+++ b/src/pulsemeeter/model/config_model.py
@@ -17,9 +17,9 @@ class ConfigModel(BaseModel):
     tray: bool = False
     layout: str = 'Blocks'
     window_width: int = 800
+    window_height: int = 600
 
     @field_validator('layout')
     @classmethod
     def capitalize_layout(cls, v):
         return v.capitalize()
-    window_height: int = 600

--- a/src/pulsemeeter/model/connection_model.py
+++ b/src/pulsemeeter/model/connection_model.py
@@ -18,6 +18,8 @@ class ConnectionModel(BaseModel):
     input_sel_channels: list[bool]
     output_sel_channels: list[bool]
     port_map: list[list[int]] = Field(default_factory=list)
+    route_volume: int = 100  # 0-153, per-route volume (only used when use_loopback=True)
+    use_loopback: bool = False  # opt-in for per-route volume via pw-loopback
 
     def str_port_map(self, input_sel_channels, output_sel_channels):
         '''

--- a/src/pulsemeeter/scripts/pmctl.py
+++ b/src/pulsemeeter/scripts/pmctl.py
@@ -1,3 +1,5 @@
+import re
+import time
 import shutil
 import logging
 import pulsectl
@@ -100,6 +102,195 @@ def link_channels(input_name: str, output_name: str, channel_map: str, state: bo
         link(input_port, output_port, state=state)
 
     return True
+
+
+def make_loopback_name(input_name: str, output_name: str) -> str:
+    '''
+    Generate a deterministic loopback name for a connection.
+    Sanitizes to alphanumeric, underscores, hyphens, and dots only.
+    Args:
+        input_name (str): Name of the input device.
+        output_name (str): Name of the output device.
+    Returns:
+        str: Sanitized loopback name.
+    '''
+    raw = f'pm_route_{input_name}_to_{output_name}'
+    return re.sub(r'[^a-zA-Z0-9._-]', '_', raw)
+
+
+def make_intermediate_sink_name(loopback_name: str) -> str:
+    '''
+    Generate a deterministic intermediate sink name for a b-type loopback connection.
+    Args:
+        loopback_name (str): The loopback name from make_loopback_name().
+    Returns:
+        str: The intermediate sink name ({loopback_name}_bridge).
+    '''
+    return f'{loopback_name}_bridge'
+
+
+def create_intermediate_sink(loopback_name: str, channels: int, position: list[str]) -> str:
+    '''
+    Create a temporary intermediate sink for b-type loopback routing.
+    Args:
+        loopback_name (str): The loopback name from make_loopback_name().
+        channels (int): Number of audio channels.
+        position (list[str]): Channel map positions.
+    Returns:
+        str: The intermediate sink name.
+    '''
+    sink_name = make_intermediate_sink_name(loopback_name)
+    create_device('sink', sink_name, channels, position)
+    return sink_name
+
+
+def remove_intermediate_sink(loopback_name: str):
+    '''
+    Remove a temporary intermediate sink for b-type loopback routing.
+    Args:
+        loopback_name (str): The loopback name from make_loopback_name().
+    '''
+    sink_name = make_intermediate_sink_name(loopback_name)
+    try:
+        remove_device(sink_name)
+    except RuntimeError:
+        LOG.warning('Failed to remove intermediate sink %s', sink_name)
+
+
+def wait_for_device(device_type: str, device_name: str, timeout: float = 2.0, interval: float = 0.05) -> bool:
+    '''
+    Poll until a device appears in PulseAudio.
+    Args:
+        device_type (str): 'sink' or 'source'.
+        device_name (str): Name of the device.
+        timeout (float): Maximum time to wait in seconds.
+        interval (float): Polling interval in seconds.
+    Returns:
+        bool: True if found, False if timed out.
+    '''
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if get_device_by_name(device_type, device_name) is not None:
+            return True
+        time.sleep(interval)
+    return False
+
+
+def get_device_serial(device_type: str, device_name: str) -> str:
+    '''
+    Get the PipeWire object.serial for a device.
+    Args:
+        device_type (str): 'sink' or 'source'.
+        device_name (str): Name of the device.
+    Returns:
+        str: The object.serial, or empty string if not found.
+    '''
+    device = get_device_by_name(device_type, device_name)
+    if device:
+        return device.proplist.get('object.serial', '')
+    return ''
+
+
+def create_loopback(name: str, capture_serial: str, playback_serial: str, channels: int) -> subprocess.Popen:
+    '''
+    Spawn a pw-loopback subprocess for per-route volume control.
+    Targets devices by PipeWire object.serial for unambiguous routing.
+    Args:
+        name (str): Unique loopback name.
+        capture_serial (str): PipeWire object.serial of the capture device.
+        playback_serial (str): PipeWire object.serial of the playback device.
+        channels (int): Number of audio channels.
+    Returns:
+        subprocess.Popen: The loopback subprocess handle.
+    '''
+    command = [
+        'pw-loopback',
+        '--name', name,
+        '--channels', str(channels),
+        '--capture-props', f'target.object={capture_serial}',
+        '--playback-props', f'target.object={playback_serial}',
+    ]
+
+    LOG.debug('Creating loopback: %s', command)
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return proc
+
+
+def destroy_loopback(proc: subprocess.Popen):
+    '''
+    Terminate a pw-loopback subprocess.
+    Args:
+        proc (subprocess.Popen): The loopback process to terminate.
+    '''
+    if proc and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    LOG.debug('Loopback destroyed (pid=%s)', proc.pid if proc else None)
+
+
+def set_route_volume(loopback_name: str, volume: int) -> bool:
+    '''
+    Set the volume of a pw-loopback sink-input by its loopback name.
+    Args:
+        loopback_name (str): The loopback name used when creating.
+        volume (int): Volume value (0-153).
+    Returns:
+        bool: True on success, False if sink-input not found.
+    '''
+    volume = min(max(0, volume), 153)
+    try:
+        for si in PULSE.sink_input_list():
+            if loopback_name in si.name:
+                channels = len(si.volume.values)
+                vol = pulsectl.PulseVolumeInfo(volume / 100, channels)
+                PULSE.volume_set(si, vol)
+                return True
+    except pulsectl.PulseError:
+        LOG.error('Failed to set route volume for %s', loopback_name)
+    return False
+
+
+def wait_for_loopback(loopback_name: str, timeout: float = 2.0, interval: float = 0.05) -> bool:
+    '''
+    Poll until the pw-loopback sink-input appears in PulseAudio.
+    Args:
+        loopback_name (str): The loopback name to wait for.
+        timeout (float): Maximum time to wait in seconds.
+        interval (float): Polling interval in seconds.
+    Returns:
+        bool: True if found, False if timed out.
+    '''
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            for si in PULSE.sink_input_list():
+                if loopback_name in si.name:
+                    return True
+        except pulsectl.PulseError:
+            pass
+        time.sleep(interval)
+    return False
+
+
+def loopback_exists(loopback_name: str) -> bool:
+    '''
+    Check if a pw-loopback sink-input with the given name already exists.
+    Args:
+        loopback_name (str): The loopback name to check for.
+    Returns:
+        bool: True if found.
+    '''
+    try:
+        for si in PULSE.sink_input_list():
+            if loopback_name in si.name:
+                return True
+    except pulsectl.PulseError:
+        pass
+    return False
 
 
 def get_ports(port_type: str, device_name: str) -> list[str]:
@@ -442,7 +633,8 @@ def list_apps(app_type: str) -> list[PulseSinkInputInfo | PulseSourceOutputInfo]
         hasname = app.proplist.get('application.name', False)
         is_peak = '_peak' in app.proplist.get('application.name', '')
         is_pavucontrol = app.proplist.get('application.id') == 'org.PulseAudio.pavucontrol'
-        if is_peak or is_pavucontrol or not hasname:
+        is_pm_loopback = 'pm_route_' in app.proplist.get('node.name', '')
+        if is_peak or is_pavucontrol or is_pm_loopback or not hasname:
             continue
 
         app.device_name = get_app_device(app_type, app).name

--- a/src/pulsemeeter/scripts/pmctl_async.py
+++ b/src/pulsemeeter/scripts/pmctl_async.py
@@ -288,6 +288,7 @@ async def filter_results(app):
     assert 'application.name' in app.proplist
     assert '_peak' not in app.proplist['application.name']
     assert app.proplist.get('application.id') != 'org.PulseAudio.pavucontrol'
+    assert 'pm_route_' not in app.proplist.get('node.name', '')
 
     # if ('application.name' not in app.proplist
     #         or '_peak' in app.proplist['application.name']
@@ -369,7 +370,8 @@ async def get_app_by_id(app_type, app_index: int):
         if ('application.name' not in app.proplist or
                 '_peak' in app.proplist['application.name'] or
                 app.name == 'audio-volume-change' or
-                app.proplist.get('application.id') == 'org.PulseAudio.pavucontrol'):
+                app.proplist.get('application.id') == 'org.PulseAudio.pavucontrol' or
+                'pm_route_' in app.proplist.get('node.name', '')):
             return None
 
         # try:


### PR DESCRIPTION
# Description

Adds per-route volume sliders using opt-in pw-loopbacks to adjust volumes before they reach the target device.
<img width="1266" height="820" alt="image" src="https://github.com/user-attachments/assets/cc4b423b-6e44-40e9-a49d-a531f7f5b573" />

This is handled via 2 methods depending on if the destination is a sink or a virtual source output. This is because pw-loopback can't play directly to a source device. 

Sink Type:
Source Device -> [pw-loopback (Vol Control)] -> Destination Sink

Virtual Output (Source device, B-type):
Source Device -> [pw-loopback (Vol Control)] -> Intermediate Bridge Sink -> [pw-link monitor] -> Virtual Source Output

Fixes #160
Depends on #174 (Accidentally made these changes on top of #174. #174 must be merged before this PR)

`gtk_client.py`:
- Wired up two new signal handlers (route_volume, use_loopback) to the device controller.

`connection_widget.py`:
- Changed ConnectionWidget from a single Gtk.ToggleButton into a Gtk.Box containing the toggle, a loopback checkbox, and a volume slider. Checkbox/slider visibility is driven by connection state and loopback opt-in. Added route_volume and use_loopback signals.

`device_widget.py`:
- Added route_volume and use_loopback signals, connected them from each ConnectionWidget and relayed up with output type/id.

`device_controller.py`:
- Core per-route volume logic. Manages _loopback_procs and _intermediate_sinks dicts. set_connection now branches between direct pw-link and pw-loopback based on use_loopback. Adds  set_loopback_connection (with b-type intermediate sink routing), _teardown_loopback, _device_available, set_route_volume, and set_use_loopback (disconnect old method, flip, reconnect new). Cleanup terminates all loopback processes and removes intermediate sinks.

`event_controller.py`:
- Wrapped get_device_by_id in a try/except to handle PulseIndexError (transient devices disappearing mid-event).

`gtk_controller.py`:
- Added set_route_volume and set_use_loopback relay methods, wired them into the device widget signal map.

`connection_model.py`:
- Added route_volume: int = 100 and use_loopback: bool = False fields.

`pmctl.py`:
- Loopback helpers: make_loopback_name, create/destroy_loopback, create/remove_intermediate_sink, wait_for_device/loopback, get_device_serial, set_route_volume, loopback_exists. Also filters pm_route_ loopback streams out of list_apps.

`pmctl_async.py`:
- Filters pm_route_ loopback streams out of filter_results and get_app_by_id so they don't appear as user apps.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-[X] Standard use (1 week) including with and without cleanup

# Checklist : 
You don't need to do all of this, but at least check what you did
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules