### PR TITLE
Prevent creating or editing a vi or b device with an empty name

### DIFF
--- a/src/pulsemeeter/clients/gtk/widgets/content.py
+++ b/src/pulsemeeter/clients/gtk/widgets/content.py
@@ -82,7 +82,12 @@ class Content(Gtk.Box):
         self.app_box = {'sink_input': WidgetBox(), 'source_output': WidgetBox()}
 
     def _on_device_create(self, _, popover):
-        self.emit('device_new', popover.to_schema())
+        schema = popover.to_schema()
+        if len(schema['nick'].strip()) == 0:
+            return
+        if popover.device_type in ('vi', 'b') and len(schema['name'].strip()) == 0:
+            return
+        self.emit('device_new', schema)
 
     def _on_settings_pressed(self, *_):
         self.emit('settings_pressed')

--- a/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
@@ -167,8 +167,11 @@ class DeviceWidget(Gtk.Frame):
 
     def _on_settings_save(self, _):
         schema = self.popover.to_schema()
-        if len(schema['nick'].strip()) != 0:
-            self.emit('device_change', schema)
+        if len(schema['nick'].strip()) == 0:
+            return
+        if self.popover.device_type in ('vi', 'b') and len(schema['name'].strip()) == 0:
+            return
+        self.emit('device_change', schema)
 
     def _on_edit_pressed(self, *_):
         self.emit('settings_pressed', self.popover)

--- a/src/pulsemeeter/controller/device_controller.py
+++ b/src/pulsemeeter/controller/device_controller.py
@@ -45,6 +45,11 @@ class DeviceController(SignalModel):
 
         # we have to create the virtual devices first
         for device_type in ('vi', 'b'):
+            empty = [did for did, d in self.device_repository.get_devices_by_type(device_type).items()
+                     if not d.name.strip()]
+            for device_id in empty:
+                LOG.warning('Removing %s device %s with empty name', device_type, device_id)
+                self.device_repository.remove_device(device_type, device_id)
             for device_id in self.device_repository.get_devices_by_type(device_type):
                 self.init_device(device_type, device_id, cache=False)
 


### PR DESCRIPTION
Prevent creating or editing a vi or b device with an empty name & Cleanup broken configs by deleting devices with empty names instead of crashing

# Description

On #185, an error is thrown on startup when we are unable to create an virtual input or virtual output device with pmctl with an empty name. This can be done if a device is created with a nick and a name, but is then edited to blank out the name. This PR prevents the user from creating a device with no name (Previously caused error and did nothing) & prevents the user from editing a device to remove the name (Would save but throw error, then would crash pulsemeeter on ever subsequent launch).

Additionally, I included a check for empty-named devices and remove them if they exist instead of crashing.

Fixes #185 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Reproduced issue & ensured changes prevent issue
- [X] Using bad config to ensure devices are cleaned up


# Checklist : 
You don't need to do all of this, but at least check what you did
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules