### PR TITLE
Bump deploy-aur action to v4.1.3

### DIFF
--- a/.github/workflows/aur-publish-git.yml
+++ b/.github/workflows/aur-publish-git.yml
@@ -21,7 +21,7 @@ jobs:
           sed -i "s/pkgver=.*/pkgver=$version/g" PKGBUILD
           
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: pulsemeeter-git
           pkgbuild: ./PKGBUILD

--- a/.github/workflows/aur-publish-stable.yml
+++ b/.github/workflows/aur-publish-stable.yml
@@ -23,7 +23,7 @@ jobs:
           cat PKGBUILD
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: pulsemeeter
           pkgbuild: ./PKGBUILD


### PR DESCRIPTION
v2.2.5 fails with 'bash: --command: invalid option' on current Arch container images. v4 fixes the bash invocation.