### PR TITLE
Call `set_ports` with correct arguments

### DIFF
--- a/src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py
+++ b/src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py
@@ -76,7 +76,7 @@ class DeviceSettingsPopover(Gtk.Popover):
 
         self.nick_widget.set_option(device_model.nick)
         if self.device_type in ('hi', 'a'):
-            self.port_selector.set_ports(device_model.selected_channels)
+            self.port_selector.set_ports(device_model.channel_list, device_model.selected_channels)
             self.combobox_widget.set_active_name(device_model.description)
         else:
             self.name_widget.set_option(device_model.name)


### PR DESCRIPTION
# Description

Corrects `set_ports` arguments to properly load ports into the modal

Fixes #192 

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Debug testing
- [ ] Extended testing

# Checklist : 
You don't need to do all of this, but at least check what you did
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings