### PR TITLE
Correct VU Meter peak logic which causes flickering when muted

### DIFF
--- a/src/pulsemeeter/clients/gtk/widgets/common/vumeter_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/common/vumeter_widget.py
@@ -24,7 +24,7 @@ class VumeterWidget(Gtk.ProgressBar):
         # )
 
     async def update_peak(self, peak):
-        if peak <= 0.00 and self.get_sensitive() is True:
+        if peak <= 0.00:
             GLib.idle_add(self.set_fraction, 0)
             GLib.idle_add(self.set_sensitive, False)
         else:


### PR DESCRIPTION
# Description

VU Meter peak logic flips the meter on and off rapidly causing a flicker when:
- VU Meters are on
- Peak volume <= 0.00 (Muted)

Fixes #182 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Normal Use

# Checklist : 
You don't need to do all of this, but at least check what you did
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings