### PR TITLE
Hotplugging & Failed Device/Route Init Indicator

### DIFF
--- a/src/pulsemeeter/clients/gtk/gtk_client.py
+++ b/src/pulsemeeter/clients/gtk/gtk_client.py
@@ -147,6 +147,8 @@ class GtkClient(Gtk.Application):
             'device_new': self.device_controller.create_device,
             'device_remove': self.device_controller.remove_device,
             'device_change': self.device_controller.update_device,
+            'pa_hotplug': self.device_controller.handle_hotplug,
+            'pa_unplug': self.device_controller.handle_unplug,
             'app_volume': self.app_controller.set_volume,
             'app_mute': self.app_controller.set_mute,
             'app_device': self.app_controller.change_device,
@@ -168,6 +170,8 @@ class GtkClient(Gtk.Application):
     def connect_event_controller_events(self):
         signal_map = {
             'pa_device_change': self.gtk_controller.pa_device_change_callback,
+            'pa_device_new': self.gtk_controller.pa_device_new_callback,
+            'pa_device_remove': self.gtk_controller.pa_device_remove_callback,
             'pa_primary_change': self.gtk_controller.pa_primary_change_callback,
             'pa_app_change': self.gtk_controller.app_change_callback,
             'pa_app_new': self.gtk_controller.app_new_callback,

--- a/src/pulsemeeter/clients/gtk/layouts/device/bars.py
+++ b/src/pulsemeeter/clients/gtk/layouts/device/bars.py
@@ -56,6 +56,7 @@ def arrange_widgets(device_widget: DeviceWidget):
     _set_properties(device_widget)
 
     name_container = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5, halign=Gtk.Align.CENTER)
+    name_container.append(device_widget.warning_icon)
     name_container.append(device_widget.nick_label)
     name_container.append(device_widget.edit_button)
 

--- a/src/pulsemeeter/clients/gtk/layouts/device/blocks.py
+++ b/src/pulsemeeter/clients/gtk/layouts/device/blocks.py
@@ -38,6 +38,7 @@ def arrange_widgets(device_widget: DeviceWidget):
     control_grid = Gtk.Grid(hexpand=True)
 
     name_container = Gtk.Box(margin_start=0, margin_end=0, hexpand=True, orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+    name_container.append(device_widget.warning_icon)
     name_container.append(device_widget.nick_label)
     name_container.append(device_widget.description_label)
     # name_container.append(Gtk.Box(hexpand=True))

--- a/src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py
@@ -25,8 +25,15 @@ class ConnectionWidget(Gtk.Box):
         self.set_hexpand(True)
         self.connection_model = connection_model
 
-        # Toggle button (existing connection toggle)
-        self.toggle_button = Gtk.ToggleButton(label=label, active=connection_model.state)
+        # Warning icon shown when route fails to set up
+        self.warning_icon = Gtk.Image.new_from_icon_name('dialog-warning')
+
+        # Toggle button with [warning_icon | label] as its content
+        toggle_content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4, halign=Gtk.Align.CENTER)
+        toggle_content.append(self.warning_icon)
+        toggle_content.append(Gtk.Label(label=label))
+        self.toggle_button = Gtk.ToggleButton(active=connection_model.state)
+        self.toggle_button.set_child(toggle_content)
         self.toggle_button.set_size_request(120, -1)
         self._toggle_handler_id = self.toggle_button.connect('toggled', self._on_toggled)
 
@@ -60,9 +67,12 @@ class ConnectionWidget(Gtk.Box):
         self.append(self.loopback_check)
         self.append(self.volume_scale)
 
-        # Initial visibility
+        # Initial visibility. set_accessible() must run before update_warning()
+        # because it sets a default tooltip on the toggle button - update_warning
+        # then overrides that tooltip with the error message when failed.
         self._update_visibility()
         self.set_accessible()
+        self.update_warning()
 
     def set_accessible(self):
         description_label = _('Connect to %s, right click to open connection settings') % self.connection_model.nick
@@ -77,13 +87,27 @@ class ConnectionWidget(Gtk.Box):
         self.loopback_check.set_visible(is_connected)
         self.volume_scale.set_visible(is_connected and use_loopback)
 
+    def update_warning(self):
+        """
+        Show warning when this route has a real failure.
+        """
+        failed = bool(getattr(self.connection_model, 'connect_failed', False))
+        self.warning_icon.set_visible(failed)
+        if failed:
+            error = getattr(self.connection_model, 'connect_error', '') or _('Failed to create route')
+            self.toggle_button.set_tooltip_text(error)
+        else:
+            self.set_accessible() # Restores normal tooltip
+
     def _on_toggled(self, widget):
         self._update_visibility()
         self.emit('connection', widget.get_active())
+        self.update_warning()
 
     def _on_loopback_toggled(self, widget):
         self._update_visibility()
         self.emit('use_loopback', widget.get_active())
+        self.update_warning()
 
     def _on_volume_changed(self, widget):
         self.emit('route_volume', int(widget.get_value()))

--- a/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/device/device_widget.py
@@ -52,6 +52,7 @@ class DeviceWidget(Gtk.Frame):
         self.device_model = model
         self._create_widgets(model)
         self._connect_callbacks()
+        self._update_warning()
 
     def _create_widgets(self, model):
         # self.name_widget = NameWidget(model.nick, model.description)
@@ -60,6 +61,8 @@ class DeviceWidget(Gtk.Frame):
         self.description_label = Gtk.Label(label=self.device_model.description)
         self.description_label.set_visible(self.device_model.nick != self.device_model.description)
         self.name_label = Gtk.Label(label=self.device_model.name)
+        # Warning icon shown when device fails to initialize
+        self.warning_icon = Gtk.Image.new_from_icon_name('dialog-warning')
         self.volume_widget = VolumeWidget(value=model.volume[0], draw_value=True)
         self.mute_widget = MuteWidget(active=model.mute)
         self.vumeter_widget = VumeterWidget()
@@ -121,6 +124,42 @@ class DeviceWidget(Gtk.Frame):
         self.nick_label.set_label(self.device_model.nick)
         self.description_label.set_label(self.device_model.description)
         self.description_label.set_visible(self.device_model.nick != self.device_model.description)
+        self._update_warning()
+
+    def _update_warning(self):
+        '''
+        Two-state visual:
+          - init_failed: warning triangle next to the name + tooltip with the error
+          - not present (without init_failed): grey out the name labels +
+            tooltip explaining the device is disconnected
+          - otherwise: normal state
+        '''
+        failed = bool(getattr(self.device_model, 'init_failed', False))
+        present = bool(getattr(self.device_model, 'present', True))
+        self.warning_icon.set_visible(failed)
+
+        if failed:
+            error = getattr(self.device_model, 'init_error', '') or _('Failed to create device')
+            self.warning_icon.set_tooltip_text(error)
+            for label in (self.nick_label, self.description_label):
+                label.set_sensitive(True)
+                label.set_tooltip_text(error)
+        elif not present:
+            disconnected = _('Device disconnected: %s') % self.device_model.name
+            for label in (self.nick_label, self.description_label):
+                label.set_sensitive(False)
+                label.set_tooltip_text(disconnected)
+        else:
+            for label in (self.nick_label, self.description_label):
+                label.set_sensitive(True)
+                label.set_tooltip_text(None)
+
+    def refresh_warnings(self):
+        '''Refresh own and child route warning indicators from current model state.'''
+        self._update_warning()
+        for output_type, widget_box in self.connections_widgets.items():
+            for connection_widget in widget_box.widgets.values():
+                connection_widget.update_warning()
 
     def reload_connection_widgets(self):
         self.connections_widgets['a'].clear()

--- a/src/pulsemeeter/controller/device_controller.py
+++ b/src/pulsemeeter/controller/device_controller.py
@@ -49,18 +49,40 @@ class DeviceController(SignalModel):
         # we have to create the virtual devices first
         for device_type in ('vi', 'b'):
             for device_id in self.device_repository.get_devices_by_type(device_type):
-                try:
-                    self.init_device(device_type, device_id, cache=False)
-                except Exception as e:
-                    LOG.error("Skipping init for %s/%s: %s", device_type, device_id, e)
+                self._try_init_device(device_type, device_id, "Skipping init for %s/%s", cache=False)
+
+        # Mark any devices PA doesn't currently know about as not present
+        for device_type in ('vi', 'b', 'hi', 'a'):
+            for device_id, device in self.device_repository.get_devices_by_type(device_type).items():
+                if device.init_failed:
+                    continue
+                device.present = pmctl.device_exists(device.name)
 
         # now we connect the input devices
         for device_type in ('vi', 'hi'):
             for device_id in self.device_repository.get_devices_by_type(device_type):
                 try:
                     self.reconnect(device_type, device_id)
-                except Exception as e:
-                    LOG.error("Skipping reconnect for %s/%s: %s", device_type, device_id, e)
+                except Exception:
+                    LOG.exception("Skipping reconnect for %s/%s", device_type, device_id)
+
+    def _try_init_device(self, device_type, device_id, log_msg, cache=True):
+        """
+        init_device with status-flag bookkeeping. Returns True on success.
+        Centralizes the init_failed / init_error update so the four call
+        sites (startup, hot-plug, update, create) stay consistent.
+        """
+        device = self.device_repository.get_device(device_type, device_id)
+        try:
+            self.init_device(device_type, device_id, cache=cache)
+            device.init_failed = False
+            device.init_error = ''
+            return True
+        except Exception as e:
+            LOG.exception(log_msg, device_type, device_id)
+            device.init_failed = True
+            device.init_error = str(e)
+            return False
 
     def init_device(self, device_type, device_id, cache=True):
         '''
@@ -95,6 +117,36 @@ class DeviceController(SignalModel):
         for input_type in ('hi', 'vi'):
             for input_id in self.device_repository.get_devices_by_type(input_type):
                 self.set_connection(input_type, input_id, device_type, device_id, state, soft=True)
+
+    def handle_hotplug(self, device_type: str, device_id: str):
+        """
+        Re-establish a configured device after it (re)appears in PulseAudio.
+
+        Retries init for previously-failed virtual devices, clears the
+        init-failure flag for hardware, marks the device present, then
+        reconnects all routes touching it. Connection-level failure flags
+        are refreshed as a side effect of set_connection.
+        """
+        device = self.device_repository.get_device(device_type, device_id)
+
+        if device_type in ('vi', 'b') and device.init_failed:
+            self._try_init_device(device_type, device_id, "Hot-plug init retry failed for %s/%s")
+        elif device_type in ('hi', 'a'):
+            device.init_failed = False
+            device.init_error = ''
+
+        device.present = True
+        self.reconnect(device_type, device_id)
+
+    def handle_unplug(self, device_type: str, device_id: str):
+        """
+        Mark a configured device as no longer present after it disappears
+        from PulseAudio. This is treated as a soft "disconnected" state -
+        not a hard error - so route-level connect_failed flags are left
+        alone (the dimmed device name communicates the issue).
+        """
+        device = self.device_repository.get_device(device_type, device_id)
+        device.present = False
 
     def reconnect(self, device_type: str, device_id: str):
         '''
@@ -145,8 +197,7 @@ class DeviceController(SignalModel):
             self.handle_output_change(device_type, device_id)
 
         if device_type in ('vi', 'b'):
-            self.init_device(device_type, device_id)
-            if device.primary:
+            if self._try_init_device(device_type, device_id, "Failed to init %s/%s on update") and device.primary:
                 pmctl.set_primary(device.device_type, device.name)
 
         self.reconnect(device_type, device_id)
@@ -254,7 +305,16 @@ class DeviceController(SignalModel):
 
         loopback_name = pmctl.make_loopback_name(input_device.name, output_device.name)
 
-        # Skip PA operations if either device is disconnected
+        # Disconnects always clear the failure flag
+        if not state:
+            connection_model.connect_failed = False
+            connection_model.connect_error = ''
+
+        # Skip PA operations if either device is disconnected. We do NOT flag
+        # the route as failed here - a device-level problem is already
+        # communicated by the device widget itself (warning triangle for a
+        # real error, dimmed name for a soft "not present"). Route warnings
+        # are reserved for failures that originate at the route level.
         if state and not self._device_available(input_device):
             LOG.warning('Input device unavailable, skipping connection: %s', input_device.name)
             return
@@ -285,8 +345,18 @@ class DeviceController(SignalModel):
         port_map = connection_model.str_port_map(input_sel_channels, output_sel_channels)
         try:
             pmctl.link_channels(input_device.name, output_device.name, port_map, state)
-        except RuntimeError:
-            LOG.error("Device ports not found, device probably disconnected")
+            if state:
+                connection_model.connect_failed = False
+                connection_model.connect_error = ''
+        except Exception as e:
+            # Broad catch: pmctl.link_channels can raise RuntimeError (missing
+            # ports) or IndexError/ValueError (malformed port_map). Crashing
+            # here would abort reconnect for sibling routes, so we flag and
+            # continue.
+            LOG.exception("Failed to link %s -> %s", input_device.name, output_device.name)
+            if state:
+                connection_model.connect_failed = True
+                connection_model.connect_error = f'Link failed: {e}'
 
     def _set_loopback_connection(self, loopback_name, input_device, output_device, connection_model, state):
         '''pw-loopback connection for per-route volume control.'''
@@ -297,6 +367,8 @@ class DeviceController(SignalModel):
             if pmctl.loopback_exists(loopback_name):
                 LOG.debug('Loopback %s already exists, adopting', loopback_name)
                 pmctl.set_route_volume(loopback_name, connection_model.route_volume)
+                connection_model.connect_failed = False
+                connection_model.connect_error = ''
                 return
 
             self._teardown_loopback(loopback_name, output_device)
@@ -339,8 +411,12 @@ class DeviceController(SignalModel):
                     else:
                         LOG.warning('Loopback %s did not appear in time', loopback_name)
                 threading.Thread(target=_wait_and_set_volume, daemon=True).start()
-            except Exception:
-                LOG.error('Failed to create loopback %s, device probably disconnected', loopback_name)
+                connection_model.connect_failed = False
+                connection_model.connect_error = ''
+            except Exception as e:
+                LOG.exception('Failed to create loopback %s', loopback_name)
+                connection_model.connect_failed = True
+                connection_model.connect_error = f'Failed to create loopback: {e}'
         else:
             self._teardown_loopback(loopback_name, output_device)
 
@@ -517,7 +593,8 @@ class DeviceController(SignalModel):
         else:
             self.handle_new_output(device_type, device_id, device)
 
-        self.init_device(device_type, device_id)
+        self._try_init_device(device_type, device_id, "Failed to init new %s/%s")
+
         self.emit('device_new', device_type, device_id, device)
         return device_type, device_id, device
 

--- a/src/pulsemeeter/controller/event_controller.py
+++ b/src/pulsemeeter/controller/event_controller.py
@@ -2,6 +2,7 @@ import time
 import asyncio
 import logging
 import pulsectl
+import pulsectl_asyncio
 import threading
 import traceback
 import concurrent
@@ -28,6 +29,12 @@ class EventController(SignalModel):
             Emitted when an application stream changes.
         pa_device_change(device_type: str, device_id: str, device_model: DeviceModel):
             Emitted when a device changes.
+        pa_device_new(device_type: str, device_id: str):
+            Emitted when a previously configured device appears in PulseAudio
+            (e.g. hardware hot-plug).
+        pa_device_remove(device_type: str, device_id: str):
+            Emitted when a previously configured device disappears from
+            PulseAudio (e.g. hardware unplug, externally-removed virtual).
         pa_primary_change(device_type: str, device_id: str | None):
             Emitted when the primary device changes.
 
@@ -53,6 +60,10 @@ class EventController(SignalModel):
         self._async_loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._async_loop.run_forever, daemon=True)
         self._thread.start()
+        # Cache of (facility, pa_index) -> pa_device_name. Populated on every
+        # device 'new'/'change' event so we can resolve removed devices by
+        # index after PA has already discarded them.
+        self._pa_index_cache: dict[tuple[str, int], str] = {}
 
     def _handle_listen_error(self, fut):
         try:
@@ -95,7 +106,11 @@ class EventController(SignalModel):
             ('app', 'change'): self._handle_app_change_event,
             ('server', 'change'): self._handle_server_change_event,
             ('device', 'change'): self._handle_device_change_event,
+            ('device', 'new'): self._handle_device_new_event,
+            ('device', 'remove'): self._handle_device_remove_event,
         }
+
+        await self._seed_pa_index_cache()
 
         # async for event in pmctl_async.pulse_listener():
         async for event in pmctl_async.pulse_listener():
@@ -103,6 +118,21 @@ class EventController(SignalModel):
             handler = _pa_event_map.get((pm_facility, event.type))
             if handler:
                 await handler(event)
+
+    async def _seed_pa_index_cache(self):
+        '''
+        Snapshot the current sink/source indices so we can resolve names on
+        remove events for devices that were already present at startup
+        (otherwise we'd only know about devices that fired new/change while
+        we were listening).
+        '''
+        try:
+            async with pulsectl_asyncio.PulseAsync() as pulse:
+                for facility, list_call in (('sink', pulse.sink_list), ('source', pulse.source_list)):
+                    for dev in await list_call():
+                        self._pa_index_cache[(facility, dev.index)] = dev.name
+        except Exception as e:
+            LOG.warning('Failed to seed PA index cache: %s', e)
 
     async def _handle_app_new_event(self, event: pulsectl.PulseEventInfo):
         '''
@@ -148,6 +178,39 @@ class EventController(SignalModel):
         app_model = AppModel.pa_to_app_model(app, app_type)
         self.emit('pa_app_change', app_type, app_index, app_model)
 
+    async def _handle_device_new_event(self, event):
+        '''
+        Handle a device new event (e.g. hardware hot-plug).
+        Looks up any configured pm devices matching the PA device name
+        and emits pa_device_new so routes can be reconnected.
+        '''
+        try:
+            pa_device = await pmctl_async.get_device_by_id(event.facility, event.index)
+        except pulsectl.pulsectl.PulseIndexError:
+            return
+
+        self._pa_index_cache[(event.facility, event.index)] = pa_device.name
+
+        pm_device_types = ('hi', 'b') if event.facility == 'source' else ('vi', 'a')
+        search_res = self.device_repository.find_device_by_key('name', pa_device.name, pm_device_types)
+        for device_type, device_id, _ in search_res:
+            self.emit('pa_device_new', device_type, device_id)
+
+    async def _handle_device_remove_event(self, event):
+        '''
+        Handle a device remove event (e.g. hardware unplug, externally-removed
+        virtual). PA has already discarded the device, so we resolve its name
+        from the index cache populated by previous new/change events.
+        '''
+        pa_name = self._pa_index_cache.pop((event.facility, event.index), None)
+        if pa_name is None:
+            return
+
+        pm_device_types = ('hi', 'b') if event.facility == 'source' else ('vi', 'a')
+        search_res = self.device_repository.find_device_by_key('name', pa_name, pm_device_types)
+        for device_type, device_id, _ in search_res:
+            self.emit('pa_device_remove', device_type, device_id)
+
     async def _handle_device_change_event(self, event):
         '''
         Handle a device change event.
@@ -158,6 +221,9 @@ class EventController(SignalModel):
             pa_device = await pmctl_async.get_device_by_id(event.facility, event.index)
         except pulsectl.pulsectl.PulseIndexError:
             return
+
+        self._pa_index_cache[(event.facility, event.index)] = pa_device.name
+
         pm_device_types = ('hi', 'b') if event.facility == 'source' else ('vi', 'a')
         device_search = self.device_repository.find_device_by_key
         search_res = device_search('name', pa_device.name, pm_device_types)

--- a/src/pulsemeeter/controller/gtk_controller.py
+++ b/src/pulsemeeter/controller/gtk_controller.py
@@ -56,6 +56,12 @@ class GtkController(SignalModel):
             Emitted when an application's mute state is changed.
         app_device(app_type: str, app_index: str, device_nick: str):
             Emitted when an application's device is changed.
+        pa_hotplug(device_type: str, device_id: str):
+            Emitted on the GTK main thread when a configured device reappears
+            in PulseAudio and needs the device controller to re-init/reconnect.
+        pa_unplug(device_type: str, device_id: str):
+            Emitted on the GTK main thread when a configured device disappears
+            from PulseAudio and the device controller should mark it absent.
     '''
 
     window: Gtk.Window
@@ -613,6 +619,39 @@ class GtkController(SignalModel):
             return False
 
         GLib.idle_add(wrapper)
+
+    def refresh_all_warnings(self):
+        """
+        Walk every device widget and re-sync its warning state (device + routes)
+        from the current model. Called after a hot-plug because a single
+        device appearing can resolve route failures across many input devices.
+        """
+        for device_type in self.content.device_box:
+            for device_widget in self.content.device_box[device_type].widgets.values():
+                device_widget.refresh_warnings()
+
+    def pa_device_new_callback(self, device_type: str, device_id: str):
+        self._dispatch_pa_device_event(device_type, device_id, 'pa_hotplug', "Hot-plug")
+
+    def pa_device_remove_callback(self, device_type: str, device_id: str):
+        self._dispatch_pa_device_event(device_type, device_id, 'pa_unplug', "Unplug")
+
+    def _dispatch_pa_device_event(self, device_type: str, device_id: str, signal_name: str, kind: str):
+        """
+        Send a hot-plug/unplug event from the EventController's asyncio
+        thread to the GTK main thread, run the device-controller logic via
+        signal, then refresh warning indicators. Refresh runs even if the
+        handler raises so the UI never gets stuck on a stale state.
+        """
+        def run_on_main():
+            try:
+                self.emit(signal_name, device_type, device_id)
+            except Exception:
+                LOG.exception("%s handling failed for %s/%s", kind, device_type, device_id)
+            self.refresh_all_warnings()
+            return False
+
+        GLib.idle_add(run_on_main)
 
     def pa_primary_change_callback(self, device_type: str, device_id: str):
         def wrapper():

--- a/src/pulsemeeter/model/connection_model.py
+++ b/src/pulsemeeter/model/connection_model.py
@@ -21,6 +21,10 @@ class ConnectionModel(BaseModel):
     route_volume: int = 100  # 0-153, per-route volume (only used when use_loopback=True)
     use_loopback: bool = False  # opt-in for per-route volume via pw-loopback
 
+    # Transient runtime status, prevent saving to config
+    connect_failed: bool = Field(default=False, exclude=True)
+    connect_error: str = Field(default='', exclude=True)
+
     def str_port_map(self, input_sel_channels, output_sel_channels):
         '''
         Returns a string formated portmap for pmctl

--- a/src/pulsemeeter/model/device_model.py
+++ b/src/pulsemeeter/model/device_model.py
@@ -2,7 +2,7 @@ import re
 import logging
 from typing import Literal
 from pulsemeeter.schemas.typing import Volume, PaDeviceType, DeviceClass
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Field, root_validator, validator
 # from pulsemeeter.schemas.device_schema import ConnectionModel
 from pulsemeeter.scripts import pmctl
 from pulsemeeter.schemas import pulse_mappings
@@ -32,6 +32,14 @@ class DeviceModel(BaseModel):
     connections: dict[str, dict[str, ConnectionModel]] = {'a': {}, 'b': {}}
     selected_channels: list[bool] | None
     # plugins: list[PluginSchema] = []
+
+    # Transient runtime status (not persisted).
+    # init_failed/init_error: hard error (e.g. pw-cli failed to create) - UI shows warning.
+    # present: whether the underlying PA device currently exists. If False
+    # without an init_failed, the UI just dims the device name as "disconnected".
+    init_failed: bool = Field(default=False, exclude=True)
+    init_error: str = Field(default='', exclude=True)
+    present: bool = Field(default=True, exclude=True)
 
     @root_validator(pre=True)
     def set_nick_description(cls, values):

--- a/src/pulsemeeter/scripts/pmctl.py
+++ b/src/pulsemeeter/scripts/pmctl.py
@@ -37,8 +37,9 @@ def create_device(device_type: str, name: str, channels: int, position: list[str
     }}'''
     command = ['pw-cli', 'create-node', 'adapter', data]
     ret, stdout, stderr = run_command(command, split=False)
-    if ret != 0:
-        raise RuntimeError(f"Failed to create device: {stderr}")
+    # pw-cli exits 0 even on protocol/syntax failures; detect those via stderr
+    if ret != 0 or 'error' in (stderr or '').lower():
+        raise RuntimeError(f"Failed to create device: {(stderr or stdout).strip() or 'pw-cli reported failure'}")
     return True
 
 
@@ -93,6 +94,8 @@ def link_channels(input_name: str, output_name: str, channel_map: str, state: bo
     output_ports = get_ports('input', output_name)
 
     if not input_ports or not output_ports:
+        if not state:
+            return True
         raise RuntimeError(f'Ports not found for devices {input_name} {output_name}')
 
     for pair in channel_map.split(' '):


### PR DESCRIPTION
- Set up hot-plugging for live device connection/disconnection without reconnecting routes
- Error indicators for devices that fail to initialize or routes that fail to connect (Tool tip for error, traceback logged)
- Disconnected indicator for devices (Tool tip shows detail)
- Better detect pw-cli failures (pw-cli can return non-0 but still fail)