### PR TITLE
Fix .desktop file naming for proper app icon resolving for window icon

### DIFF
--- a/makefile
+++ b/makefile
@@ -37,6 +37,7 @@ uninstall:
 		${DESTDIR}${PREFIX}/share/licenses/pulsemeeter \
 		${DESTDIR}${PREFIX}/share/doc/pulsemeeter \
 		${DESTDIR}${PREFIX}/share/applications/pulsemeeter.desktop \
+		${DESTDIR}${PREFIX}/share/applications/org.pulsemeeter.pulsemeeter.desktop \
 		${DESTDIR}${PREFIX}/share/locale/*/LC_MESSAGES/pulsemeeter.mo \
 		${DESTDIR}${PREFIX}/share/icons/hicolor/*/apps/Pulsemeeter.png \
 

--- a/share/applications/org.pulsemeeter.pulsemeeter.desktop
+++ b/share/applications/org.pulsemeeter.pulsemeeter.desktop
@@ -6,4 +6,3 @@ Icon=Pulsemeeter
 Exec=pulsemeeter
 StartupWMClass=org.pulsemeeter.pulsemeeter
 Categories=Audio;AudioVideo;Midi;X-Alsa;X-Jack;X-AudioEditing;
-NoDisplay=true


### PR DESCRIPTION
Fixes the window icon appearing as the fallback wayland icon due to the .desktop file not resolving in the lookup. We create a new .desktop and set the old one to NoDisplay=true instead of replacing/renaming the file which would break users pins & prevents multiple from appearing in the launcher