### PR TITLE
Inline install_requires so builds work on old setuptools (#166)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,11 @@ classifiers =
 include_package_data = True
 packages = find:
 python_requires = >=3.10
-install_requires = file: requirements.txt
+install_requires =
+	pulsectl
+	pulsectl_asyncio
+	pygobject
+	pydantic
 scripts = src/scripts/pmctl
 package_dir = 
 	= src


### PR DESCRIPTION
Distros shipping older setuptools (e.g. Mint 21.2) parse the literal string as a requirement and fail with InvalidRequirement during 'pip install .'

requirements.txt stays for the dev installs & CI lint job

In the future, project should be migrated to a pyproject.toml which lists the dependencies as a single source of truth

Fixes #166 