### PR TITLE
Prevent CI jobs running multiple times on merged PRs to main

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -1,6 +1,9 @@
 name: i18n Catalog Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   check-catalogs:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,9 @@
 name: Pylint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
CI Jobs run twice when a PR is getting merged into main. Changing push to main only prevents this. If we need CI job on forks then we'd use a Draft PR instead