### PR TITLE
Spanish (LATAM) translation

### DIFF
--- a/locale/es/LC_MESSAGES/pulsemeeter.po
+++ b/locale/es/LC_MESSAGES/pulsemeeter.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulsemeeter 2.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-12 14:54-0600\n"
+"POT-Creation-Date: 2026-07-12 20:38-0600\n"
 "PO-Revision-Date: 2026-07-12 17:47-0600\n"
-"Last-Translator: GabrielMuSa"
+"Last-Translator: GabrielMuSa\n"
 "Language: es\n"
 "Language-Team: es <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -44,7 +44,7 @@ msgstr "Abrir el menú de configuración"
 
 #: src/pulsemeeter/clients/gtk/widgets/content.py:78
 msgid "Settings menu"
-msgstr "Menú de configuración "
+msgstr "Menú de configuración"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:18
 msgid "What is Pulsemeeter?"
@@ -56,9 +56,10 @@ msgid ""
 " It lets you create virtual devices and freely route audio between your "
 "inputs and outputs, controlling volume and muting along the way."
 msgstr ""
-"Pulsemeeter es un mezclador y enrutador de audio virtual basado en PipeWire."
-" Permite crear dispositivos virtuales y conectar libremente el audio "
-"entre las entradas y salidas, controlando el volumen y silenciandolo a voluntad."
+"Pulsemeeter es un mezclador y enrutador de audio virtual basado en "
+"PipeWire. Permite crear dispositivos virtuales y conectar libremente el "
+"audio entre las entradas y salidas, controlando el volumen y "
+"silenciandolo a voluntad."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:24
 msgid "The four device types"
@@ -74,10 +75,14 @@ msgid ""
 "<b>Virtual Outputs</b> are virtual sources that applications can capture "
 "from."
 msgstr ""
-"<b>Entradas de Hardware</b> son fuentes físicas como micrófonos y entradas de línea.\n"
-"<b>Entradas Virtuales</b> son receptores de audio en las que las aplicaciones pueden reproducirse.\n"
-"<b>Salidas de Hardware</b> son salidas físicas como altavoces y audifonos.\n"
-"<b>Salidas Virtuales</b> son salidas virtuales en las que las aplicaciones pueden capturar audio."
+"<b>Entradas de Hardware</b> son fuentes físicas como micrófonos y "
+"entradas de línea.\n"
+"<b>Entradas Virtuales</b> son receptores de audio en las que las "
+"aplicaciones pueden reproducirse.\n"
+"<b>Salidas de Hardware</b> son salidas físicas como altavoces y "
+"audifonos.\n"
+"<b>Salidas Virtuales</b> son salidas virtuales en las que las "
+"aplicaciones pueden capturar audio."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:31
 msgid "Routing"
@@ -90,8 +95,9 @@ msgid ""
 "toggles on each input device to send its audio to the outputs you want."
 msgstr ""
 "El audio siempre fluye de una entrada a una salida: Hardware y Virtual, "
-"las entradas se conectan a salidas de hardware y virtuales. Utilice los interruptores "
-"de conexión en cada dispositivo de entrada para enviar el audio a las salidas que prefieras."
+"las entradas se conectan a salidas de hardware y virtuales. Utilice los "
+"interruptores de conexión en cada dispositivo de entrada para enviar el "
+"audio a las salidas que prefieras."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:37
 msgid "Cleanup"
@@ -103,9 +109,9 @@ msgid ""
 "routes it creates with the cleanup setting. If Pulsemeeter is closed, it "
 "won't be able to monitor for hotplugging"
 msgstr ""
-"Pulsemeeter tiene la capacidad de abandonar o limpiar el dispositivo virtual "
-"y las rutas que crea con la configuración de limpieza. Si Pulsemeeter esta "
-"cerrado, no podra monitorear las conexiones."
+"Pulsemeeter tiene la capacidad de abandonar o limpiar el dispositivo "
+"virtual y las rutas que crea con la configuración de limpieza. Si "
+"Pulsemeeter esta cerrado, no podra monitorear las conexiones"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:43
 msgid "Primary device"
@@ -116,9 +122,9 @@ msgid ""
 "Marking a device as primary makes it the default that new applications "
 "attach to automatically. This sets the primary in PipeWire itself."
 msgstr ""
-"Marcar un dispositivo como principal lo convierte en el dispositivo predeterminado "
-"al que se conectan automáticamente las nuevas aplicaciones. Esto "
-"establece el dispositivo principal en PipeWire."
+"Marcar un dispositivo como principal lo convierte en el dispositivo "
+"predeterminado al que se conectan automáticamente las nuevas "
+"aplicaciones. Esto establece el dispositivo principal en PipeWire."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:48
 msgid "VU meters & settings"
@@ -131,23 +137,24 @@ msgid ""
 "available layouts. Enabling VU Meters will show the inputs \"in use\" by "
 "Pulsemeeter."
 msgstr ""
-"Los medidores VU muestran el nivel de volumen en tiempo real de cada dispositivo. "
-"Abra el menú de configuración para activar o desactivar los medidores VU, "
-"habilitar la limpieza al salir y cambiar entre los diseños disponibles. Al "
-"activar los medidores VU, se mostrarán las entradas \"en uso\" por Pulsemeeter."
+"Los medidores VU muestran el nivel de volumen en tiempo real de cada "
+"dispositivo. Abra el menú de configuración para activar o desactivar los "
+"medidores VU, habilitar la limpieza al salir y cambiar entre los diseños "
+"disponibles. Al activar los medidores VU, se mostrarán las entradas \"en "
+"uso\" por Pulsemeeter."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:55
 msgid ""
 "You can reopen this guide any time from the information button in the "
 "settings menu."
 msgstr ""
-"Puedes abrir esta guia en cualquier momento desde el botón de información "
-"en el menú de configuración."
+"Puedes abrir esta guia en cualquier momento desde el botón de información"
+" en el menú de configuración."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:64
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:111
 msgid "Welcome to Pulsemeeter!"
-msgstr "¡Bienvenido a Pulsemeeter! "
+msgstr "¡Bienvenido a Pulsemeeter!"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:90
 msgid "Get started"
@@ -301,7 +308,9 @@ msgstr "Volumen de la ruta"
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:78
 #, python-format
 msgid "Connect to %s, right click to open connection settings"
-msgstr "Conectarse a %s, click al boton derecho para abrir la configuración de conexión"
+msgstr ""
+"Conectarse a %s, click al boton derecho para abrir la configuración de "
+"conexión"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:97
 msgid "Failed to create route"
@@ -343,7 +352,7 @@ msgstr "Dispositivo: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:35
 msgid "Channel Map: "
-msgstr "Mapeo del canal"
+msgstr "Mapeo del canal: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:28
 msgid "Auto ports"

--- a/locale/es/LC_MESSAGES/pulsemeeter.po
+++ b/locale/es/LC_MESSAGES/pulsemeeter.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 ORGANIZATION
 # This file is distributed under the same license as the pulsemeeter
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+# GabrielMuSa, 2026.
 #
 msgid ""
 msgstr ""
@@ -10,7 +10,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2026-07-12 14:54-0600\n"
 "PO-Revision-Date: 2026-07-12 17:47-0600\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Last-Translator: GabrielMuSa"
 "Language: es\n"
 "Language-Team: es <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -22,33 +22,33 @@ msgstr ""
 #: src/pulsemeeter/clients/cli/cli_client.py:41
 #, python-format
 msgid "Invalid device id: %s"
-msgstr ""
+msgstr "Id de dispositivo no valido: %s"
 
 #: src/pulsemeeter/clients/gtk/layouts/content/tabbed.py:52
 msgid "Settings"
-msgstr ""
+msgstr "Configuración"
 
 #: src/pulsemeeter/clients/gtk/widgets/content.py:54
 #, python-format
 msgid "Create new %s"
-msgstr ""
+msgstr "Crear nuevo %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/content.py:64
 msgid "Create device"
-msgstr ""
+msgstr "Crear dispositivo"
 
 #: src/pulsemeeter/clients/gtk/widgets/content.py:69
 #: src/pulsemeeter/clients/gtk/widgets/content.py:79
 msgid "Open settings menu"
-msgstr ""
+msgstr "Abrir el menú de configuración"
 
 #: src/pulsemeeter/clients/gtk/widgets/content.py:78
 msgid "Settings menu"
-msgstr ""
+msgstr "Menú de configuración "
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:18
 msgid "What is Pulsemeeter?"
-msgstr ""
+msgstr "¿Que es Pulsemeeter?"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:19
 msgid ""
@@ -56,10 +56,13 @@ msgid ""
 " It lets you create virtual devices and freely route audio between your "
 "inputs and outputs, controlling volume and muting along the way."
 msgstr ""
+"Pulsemeeter es un mezclador y enrutador de audio virtual basado en PipeWire."
+" Permite crear dispositivos virtuales y conectar libremente el audio "
+"entre las entradas y salidas, controlando el volumen y silenciandolo a voluntad."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:24
 msgid "The four device types"
-msgstr ""
+msgstr "Los cuatro tipos de dispositivos"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:25
 msgid ""
@@ -71,10 +74,14 @@ msgid ""
 "<b>Virtual Outputs</b> are virtual sources that applications can capture "
 "from."
 msgstr ""
+"<b>Entradas de Hardware</b> son fuentes físicas como micrófonos y entradas de línea.\n"
+"<b>Entradas Virtuales</b> son receptores de audio en las que las aplicaciones pueden reproducirse.\n"
+"<b>Salidas de Hardware</b> son salidas físicas como altavoces y audifonos.\n"
+"<b>Salidas Virtuales</b> son salidas virtuales en las que las aplicaciones pueden capturar audio."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:31
 msgid "Routing"
-msgstr ""
+msgstr "Enrutamiento"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:32
 msgid ""
@@ -82,10 +89,13 @@ msgid ""
 "Inputs connect to Hardware and Virtual Outputs. Use the connection "
 "toggles on each input device to send its audio to the outputs you want."
 msgstr ""
+"El audio siempre fluye de una entrada a una salida: Hardware y Virtual, "
+"las entradas se conectan a salidas de hardware y virtuales. Utilice los interruptores "
+"de conexión en cada dispositivo de entrada para enviar el audio a las salidas que prefieras."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:37
 msgid "Cleanup"
-msgstr ""
+msgstr "Limpieza"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:38
 msgid ""
@@ -93,20 +103,26 @@ msgid ""
 "routes it creates with the cleanup setting. If Pulsemeeter is closed, it "
 "won't be able to monitor for hotplugging"
 msgstr ""
+"Pulsemeeter tiene la capacidad de abandonar o limpiar el dispositivo virtual "
+"y las rutas que crea con la configuración de limpieza. Si Pulsemeeter esta "
+"cerrado, no podra monitorear las conexiones."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:43
 msgid "Primary device"
-msgstr ""
+msgstr "Dispositivo principal"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:44
 msgid ""
 "Marking a device as primary makes it the default that new applications "
 "attach to automatically. This sets the primary in PipeWire itself."
 msgstr ""
+"Marcar un dispositivo como principal lo convierte en el dispositivo predeterminado "
+"al que se conectan automáticamente las nuevas aplicaciones. Esto "
+"establece el dispositivo principal en PipeWire."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:48
 msgid "VU meters & settings"
-msgstr ""
+msgstr "Medidores VU y Configuración"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:49
 msgid ""
@@ -115,30 +131,36 @@ msgid ""
 "available layouts. Enabling VU Meters will show the inputs \"in use\" by "
 "Pulsemeeter."
 msgstr ""
+"Los medidores VU muestran el nivel de volumen en tiempo real de cada dispositivo. "
+"Abra el menú de configuración para activar o desactivar los medidores VU, "
+"habilitar la limpieza al salir y cambiar entre los diseños disponibles. Al "
+"activar los medidores VU, se mostrarán las entradas \"en uso\" por Pulsemeeter."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:55
 msgid ""
 "You can reopen this guide any time from the information button in the "
 "settings menu."
 msgstr ""
+"Puedes abrir esta guia en cualquier momento desde el botón de información "
+"en el menú de configuración."
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:64
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:111
 msgid "Welcome to Pulsemeeter!"
-msgstr ""
+msgstr "¡Bienvenido a Pulsemeeter! "
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:90
 msgid "Get started"
-msgstr ""
+msgstr "Empezar"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:116
 #, python-format
 msgid "Version %s"
-msgstr ""
+msgstr "Versión %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:124
 msgid "View Source"
-msgstr ""
+msgstr "Ver código fuente"
 
 #: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:132
 msgid "Discord"
@@ -147,204 +169,204 @@ msgstr ""
 #: src/pulsemeeter/clients/gtk/widgets/app/app_box_widget.py:21
 #: src/pulsemeeter/model/types.py:16
 msgid "Application Outputs"
-msgstr ""
+msgstr "Audio de salida de aplicación"
 
 #: src/pulsemeeter/clients/gtk/widgets/app/app_box_widget.py:22
 #: src/pulsemeeter/model/types.py:17
 msgid "Application Inputs"
-msgstr ""
+msgstr "Audio de entrada de aplicación"
 
 #: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:34
 #, python-format
 msgid "Select the app %s! device"
-msgstr ""
+msgstr "Seleccione el dispositivo de %s de la aplicación"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:25
 msgid "Primary"
-msgstr ""
+msgstr "Principal"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:34
 msgid "This device is primary"
-msgstr ""
+msgstr "Este es el dispositivo principal"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:36
 msgid "Set as primary device"
-msgstr ""
+msgstr "Establecer como dispositivo principal"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py:26
 #, python-format
 msgid "Select the %s"
-msgstr ""
+msgstr "Seleccione el %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:24
 msgid "Mute"
-msgstr ""
+msgstr "Silenciar"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:25
 msgid "Mute toggle"
-msgstr ""
+msgstr "Activar o desactivar silencio"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/port_selector_widget.py:19
 msgid "Selected ports: "
-msgstr ""
+msgstr "Puertos seleccionados: "
 
 #: src/pulsemeeter/clients/gtk/widgets/common/port_selector_widget.py:37
 msgid "Toggle the port "
-msgstr ""
+msgstr "Activar o desactivar el puerto "
 
 #: src/pulsemeeter/clients/gtk/widgets/common/volume_widget.py:38
 #: src/pulsemeeter/clients/gtk/widgets/common/volume_widget.py:41
 msgid "Volume Slider"
-msgstr ""
+msgstr "Barra de volumen"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:30
 #: src/pulsemeeter/model/types.py:12
 msgid "Hardware Inputs"
-msgstr ""
+msgstr "Entradas de Hardware"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:31
 #: src/pulsemeeter/model/types.py:13
 msgid "Virtual Inputs"
-msgstr ""
+msgstr "Entradas Virtuales"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:32
 #: src/pulsemeeter/model/types.py:14
 msgid "Hardware Outputs"
-msgstr ""
+msgstr "Salidas de Hardware"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:33
 #: src/pulsemeeter/model/types.py:15
 msgid "Virtual Outputs"
-msgstr ""
+msgstr "Salidas Virtuales"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:54
 #, python-format
 msgid "Create new %s device"
-msgstr ""
+msgstr "Crear nuevo dispositivo de %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:55
 #, python-format
 msgid "Create a %s device"
-msgstr ""
+msgstr "Crear un dispositivo de %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:33
 msgid "Enable VU Meters"
-msgstr ""
+msgstr "Habilitar Medidores VU"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:34
 msgid "Enable Cleanup"
-msgstr ""
+msgstr "Habilitar Limpieza"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:35
 msgid "Enable Tray"
-msgstr ""
+msgstr "Habilitar Bandeja"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:36
 msgid "Layout "
-msgstr ""
+msgstr "Diseño "
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:46
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:30
 msgid "Apply"
-msgstr ""
+msgstr "Aplicar"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:48
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:52
 msgid "Open the welcome guide"
-msgstr ""
+msgstr "Abrir la guía de bienvenida"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:54
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:55
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:56
 #, python-format
 msgid "Enable or disable %s"
-msgstr ""
+msgstr "Habilitar o deshabilitar %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:55
 msgid "VU Meter (volume peak)"
-msgstr ""
+msgstr "Medidor VU (Nivel de volumen)"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:57
 msgid "Select the GUI layout"
-msgstr ""
+msgstr "Seleccione el diseño de la interfaz"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:50
 msgid "Enable per-route volume (uses pw-loopback)"
-msgstr ""
+msgstr "Habilitar el volumen por ruta (utiliza pw-loopback)"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:62
 msgid "Route volume"
-msgstr ""
+msgstr "Volumen de la ruta"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:78
 #, python-format
 msgid "Connect to %s, right click to open connection settings"
-msgstr ""
+msgstr "Conectarse a %s, click al boton derecho para abrir la configuración de conexión"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:97
 msgid "Failed to create route"
-msgstr ""
+msgstr "No se pudo crear la ruta"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:97
 #: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:107
 msgid "Open device settings"
-msgstr ""
+msgstr "Abrir configuración del dispositivo"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:106
 msgid "Device settings"
-msgstr ""
+msgstr "Configuración del dispositivo"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:142
 msgid "Failed to create device"
-msgstr ""
+msgstr "No se pudo crear el dispositivo"
 
 #: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:148
 #, python-format
 msgid "Device disconnected: %s"
-msgstr ""
+msgstr "Dispositivo desconectado: %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:31
 msgid "Nick: "
-msgstr ""
+msgstr "Alias: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:32
 msgid "Name: "
-msgstr ""
+msgstr "Nombre: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:33
 msgid "External"
-msgstr ""
+msgstr "Externo"
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:35
 msgid "Device: "
-msgstr ""
+msgstr "Dispositivo: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:35
 msgid "Channel Map: "
-msgstr ""
+msgstr "Mapeo del canal"
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:28
 msgid "Auto ports"
-msgstr ""
+msgstr "Puertos automaticos"
 
 #: src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py:29
 #, python-format
 msgid "Enter the %s"
-msgstr ""
+msgstr "Ingrese el %s"
 
 #: src/pulsemeeter/model/types.py:22
 msgid "Physical sources such as microphones and line-in."
-msgstr ""
+msgstr "Fuentes fisicas como micrófonos y entradas de línea."
 
 #: src/pulsemeeter/model/types.py:23
 msgid "Virtual sinks that applications can play into."
-msgstr ""
+msgstr "Receptor de audio virtual en los que pueden reproducirse las aplicaciones."
 
 #: src/pulsemeeter/model/types.py:24
 msgid "Physical sinks such as speakers and headphones."
-msgstr ""
+msgstr "Receptor de audio fisico como altavoces y audifonos."
 
 #: src/pulsemeeter/model/types.py:25
 msgid "Virtual sources that applications can capture from."
-msgstr ""
+msgstr "Fuentes virtuales de las que las aplicaciones pueden capturar audio."
 

--- a/locale/es/LC_MESSAGES/pulsemeeter.po
+++ b/locale/es/LC_MESSAGES/pulsemeeter.po
@@ -1,0 +1,350 @@
+# Spanish translations for pulsemeeter.
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the pulsemeeter
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: pulsemeeter 2.1.1\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-12 14:54-0600\n"
+"PO-Revision-Date: 2026-07-12 17:47-0600\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: src/pulsemeeter/clients/cli/cli_client.py:41
+#, python-format
+msgid "Invalid device id: %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/layouts/content/tabbed.py:52
+msgid "Settings"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/content.py:54
+#, python-format
+msgid "Create new %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/content.py:64
+msgid "Create device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/content.py:69
+#: src/pulsemeeter/clients/gtk/widgets/content.py:79
+msgid "Open settings menu"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/content.py:78
+msgid "Settings menu"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:18
+msgid "What is Pulsemeeter?"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:19
+msgid ""
+"Pulsemeeter is a virtual audio mixer and router built on top of PipeWire."
+" It lets you create virtual devices and freely route audio between your "
+"inputs and outputs, controlling volume and muting along the way."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:24
+msgid "The four device types"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:25
+msgid ""
+"<b>Hardware Inputs</b> are physical sources such as microphones and line-"
+"in.\n"
+"<b>Virtual Inputs</b> are virtual sinks that applications can play into.\n"
+"<b>Hardware Outputs</b> are physical sinks such as speakers and "
+"headphones.\n"
+"<b>Virtual Outputs</b> are virtual sources that applications can capture "
+"from."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:31
+msgid "Routing"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:32
+msgid ""
+"Audio always flows from an input to an output: Hardware and Virtual "
+"Inputs connect to Hardware and Virtual Outputs. Use the connection "
+"toggles on each input device to send its audio to the outputs you want."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:37
+msgid "Cleanup"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:38
+msgid ""
+"Pulsemeeter has the ability to leave or cleanup the virtual device and "
+"routes it creates with the cleanup setting. If Pulsemeeter is closed, it "
+"won't be able to monitor for hotplugging"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:43
+msgid "Primary device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:44
+msgid ""
+"Marking a device as primary makes it the default that new applications "
+"attach to automatically. This sets the primary in PipeWire itself."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:48
+msgid "VU meters & settings"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:49
+msgid ""
+"VU meters show the live volume peak of each device. Open the settings "
+"menu to toggle VU meters, enable cleanup on exit, and switch between the "
+"available layouts. Enabling VU Meters will show the inputs \"in use\" by "
+"Pulsemeeter."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:55
+msgid ""
+"You can reopen this guide any time from the information button in the "
+"settings menu."
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:64
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:111
+msgid "Welcome to Pulsemeeter!"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:90
+msgid "Get started"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:116
+#, python-format
+msgid "Version %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:124
+msgid "View Source"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/welcome_window.py:132
+msgid "Discord"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_box_widget.py:21
+#: src/pulsemeeter/model/types.py:16
+msgid "Application Outputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_box_widget.py:22
+#: src/pulsemeeter/model/types.py:17
+msgid "Application Inputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:34
+#, python-format
+msgid "Select the app %s! device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:25
+msgid "Primary"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:34
+msgid "This device is primary"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:36
+msgid "Set as primary device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py:26
+#, python-format
+msgid "Select the %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:24
+msgid "Mute"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:25
+msgid "Mute toggle"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/port_selector_widget.py:19
+msgid "Selected ports: "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/port_selector_widget.py:37
+msgid "Toggle the port "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/common/volume_widget.py:38
+#: src/pulsemeeter/clients/gtk/widgets/common/volume_widget.py:41
+msgid "Volume Slider"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:30
+#: src/pulsemeeter/model/types.py:12
+msgid "Hardware Inputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:31
+#: src/pulsemeeter/model/types.py:13
+msgid "Virtual Inputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:32
+#: src/pulsemeeter/model/types.py:14
+msgid "Hardware Outputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:33
+#: src/pulsemeeter/model/types.py:15
+msgid "Virtual Outputs"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:54
+#, python-format
+msgid "Create new %s device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/device_box_widget.py:55
+#, python-format
+msgid "Create a %s device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:33
+msgid "Enable VU Meters"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:34
+msgid "Enable Cleanup"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:35
+msgid "Enable Tray"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:36
+msgid "Layout "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:46
+#: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:30
+msgid "Apply"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:48
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:52
+msgid "Open the welcome guide"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:54
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:55
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:56
+#, python-format
+msgid "Enable or disable %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:55
+msgid "VU Meter (volume peak)"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:57
+msgid "Select the GUI layout"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:50
+msgid "Enable per-route volume (uses pw-loopback)"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:62
+msgid "Route volume"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:78
+#, python-format
+msgid "Connect to %s, right click to open connection settings"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/connection_widget.py:97
+msgid "Failed to create route"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:97
+#: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:107
+msgid "Open device settings"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:106
+msgid "Device settings"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:142
+msgid "Failed to create device"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/device/device_widget.py:148
+#, python-format
+msgid "Device disconnected: %s"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:31
+msgid "Nick: "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:32
+msgid "Name: "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:33
+msgid "External"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:35
+msgid "Device: "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:35
+msgid "Channel Map: "
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:28
+msgid "Auto ports"
+msgstr ""
+
+#: src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py:29
+#, python-format
+msgid "Enter the %s"
+msgstr ""
+
+#: src/pulsemeeter/model/types.py:22
+msgid "Physical sources such as microphones and line-in."
+msgstr ""
+
+#: src/pulsemeeter/model/types.py:23
+msgid "Virtual sinks that applications can play into."
+msgstr ""
+
+#: src/pulsemeeter/model/types.py:24
+msgid "Physical sinks such as speakers and headphones."
+msgstr ""
+
+#: src/pulsemeeter/model/types.py:25
+msgid "Virtual sources that applications can capture from."
+msgstr ""
+


### PR DESCRIPTION
New Translation

Translation is Latin America Spanish which should technically be [es-419](https://localizely.com/locale-code/es-419/) instead of [es](https://localizely.com/language-code/es/) however until someone wants to split them out I set it up as general Spanish.

This means anyone with `LANGUAGE=es`, `es_419`, `es_MX`, `es_ES`, etc will all get this version