### PR TITLE
Disable arch build test in CI Jobs

### DIFF
--- a/.github/workflows/aur-publish-git.yml
+++ b/.github/workflows/aur-publish-git.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           pkgname: pulsemeeter-git
           pkgbuild: ./packaging/aur/git/PKGBUILD
-          test: true
-          test_flags: --clean --cleanbuild --syncdeps --noconfirm
+          test: false
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/aur-publish-stable.yml
+++ b/.github/workflows/aur-publish-stable.yml
@@ -29,8 +29,7 @@ jobs:
           pkgname: pulsemeeter
           pkgbuild: ./PKGBUILD
           updpkgsums: true
-          test: true
-          test_flags: --clean --cleanbuild --syncdeps --noconfirm
+          test: false
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
AUR isn't available in the CI environment and our dependencies require the AUR packages to build ( :frowning_face: )