### PR TITLE
Restore sed version injection

### DIFF
--- a/.github/workflows/aur-publish-git.yml
+++ b/.github/workflows/aur-publish-git.yml
@@ -11,6 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Inject computed pkgver
+        run: |
+          PKGVER="r$(git rev-list --count HEAD).g$(git rev-parse --short=7 HEAD)"
+          sed -i "s/^pkgver=.*/pkgver=$PKGVER/" packaging/aur/git/PKGBUILD
+          grep '^pkgver=' packaging/aur/git/PKGBUILD
 
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3


### PR DESCRIPTION
Since testing isn't possible, we never calculate the version (Since no build), so we need to restore the sed version injection