### PR TITLE
Removing substringing for translations

### DIFF
--- a/locale/de_DE/LC_MESSAGES/pulsemeeter.po
+++ b/locale/de_DE/LC_MESSAGES/pulsemeeter.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulsemeeter 2.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 15:43-0600\n"
+"POT-Creation-Date: 2026-08-14 17:20-0600\n"
 "PO-Revision-Date: 2025-08-28 20:33+0200\n"
 "Last-Translator: <dev.mfh@posteo.net>\n"
 "Language: German\n"
@@ -146,9 +146,14 @@ msgstr ""
 msgid "Discord"
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:34
-#, python-format
-msgid "Select the app %s! device"
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:35
+#, fuzzy
+msgid "Select the output device for this app"
+msgstr "Wähle das Gerät der App %s aus!"
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:37
+#, fuzzy
+msgid "Select the input device for this app"
 msgstr "Wähle das Gerät der App %s aus!"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:25
@@ -162,11 +167,6 @@ msgstr "Dieses Gerät ist das Standardgerät "
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:36
 msgid "Set as primary device"
 msgstr "Als Standardgerät festlegen"
-
-#: src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py:26
-#, python-format
-msgid "Select the %s"
-msgstr "Wähle %s aus"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:24
 msgid "Mute"
@@ -213,14 +213,13 @@ msgid "Open the welcome guide"
 msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
-#, python-format
-msgid "Enable or disable %s"
-msgstr "%s aktivieren oder deaktivieren"
-
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-msgid "VU Meter (volume peak)"
+#, fuzzy
+msgid "Enable or disable VU meters (volume peak)"
 msgstr "VU-Meter (Pegelspitze)"
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
+msgid "Enable or disable cleaning up devices and connections upon closing"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:43
 msgid "Select the GUI layout"
@@ -267,9 +266,17 @@ msgstr ""
 msgid "Nick: "
 msgstr "Spitzname: "
 
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:28
+msgid "Enter a nickname for the device"
+msgstr ""
+
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
 msgid "Name: "
 msgstr "Name: "
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
+msgid "Enter a name for the device"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:30
 #, fuzzy
@@ -284,22 +291,27 @@ msgid ""
 "create it onstartup or remove it on exit."
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
 msgid "Device: "
 msgstr "Gerät: "
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
+#, fuzzy
+msgid "Select a device"
+msgstr "Wähle das Gerät der App %s aus!"
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
 msgid "Channel Map: "
+msgstr "Kanalzuordnung: "
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
+#, fuzzy
+msgid "Select a channel map"
 msgstr "Kanalzuordnung: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:24
 msgid "Auto ports"
 msgstr "Automatische Ports"
-
-#: src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py:28
-#, python-format
-msgid "Enter the %s"
-msgstr "Gib %s ein"
 
 #: src/pulsemeeter/model/types.py:10
 msgid "Hardware Inputs"
@@ -349,4 +361,13 @@ msgstr ""
 
 #~ msgid "Enable Tray"
 #~ msgstr "System-Tray aktivieren"
+
+#~ msgid "Select the %s"
+#~ msgstr "Wähle %s aus"
+
+#~ msgid "Enable or disable %s"
+#~ msgstr "%s aktivieren oder deaktivieren"
+
+#~ msgid "Enter the %s"
+#~ msgstr "Gib %s ein"
 

--- a/locale/es/LC_MESSAGES/pulsemeeter.po
+++ b/locale/es/LC_MESSAGES/pulsemeeter.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulsemeeter 2.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 15:43-0600\n"
+"POT-Creation-Date: 2026-08-14 17:20-0600\n"
 "PO-Revision-Date: 2026-07-12 17:47-0600\n"
 "Last-Translator: GabrielMuSa\n"
 "Language: es\n"
@@ -173,9 +173,14 @@ msgstr "Ver código fuente"
 msgid "Discord"
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:34
-#, python-format
-msgid "Select the app %s! device"
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:35
+#, fuzzy
+msgid "Select the output device for this app"
+msgstr "Seleccione el dispositivo de %s de la aplicación"
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:37
+#, fuzzy
+msgid "Select the input device for this app"
 msgstr "Seleccione el dispositivo de %s de la aplicación"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:25
@@ -189,11 +194,6 @@ msgstr "Este es el dispositivo principal"
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:36
 msgid "Set as primary device"
 msgstr "Establecer como dispositivo principal"
-
-#: src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py:26
-#, python-format
-msgid "Select the %s"
-msgstr "Seleccione el %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:24
 msgid "Mute"
@@ -239,14 +239,13 @@ msgid "Open the welcome guide"
 msgstr "Abrir la guía de bienvenida"
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
-#, python-format
-msgid "Enable or disable %s"
-msgstr "Habilitar o deshabilitar %s"
-
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-msgid "VU Meter (volume peak)"
+#, fuzzy
+msgid "Enable or disable VU meters (volume peak)"
 msgstr "Medidor VU (Nivel de volumen)"
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
+msgid "Enable or disable cleaning up devices and connections upon closing"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:43
 msgid "Select the GUI layout"
@@ -293,9 +292,17 @@ msgstr "Dispositivo desconectado: %s"
 msgid "Nick: "
 msgstr "Alias: "
 
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:28
+msgid "Enter a nickname for the device"
+msgstr ""
+
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
 msgid "Name: "
 msgstr "Nombre: "
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
+msgid "Enter a name for the device"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:30
 #, fuzzy
@@ -310,22 +317,27 @@ msgid ""
 "create it onstartup or remove it on exit."
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
 msgid "Device: "
 msgstr "Dispositivo: "
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
+#, fuzzy
+msgid "Select a device"
+msgstr "Seleccione el dispositivo de %s de la aplicación"
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
 msgid "Channel Map: "
+msgstr "Mapeo del canal: "
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
+#, fuzzy
+msgid "Select a channel map"
 msgstr "Mapeo del canal: "
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:24
 msgid "Auto ports"
 msgstr "Puertos automaticos"
-
-#: src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py:28
-#, python-format
-msgid "Enter the %s"
-msgstr "Ingrese el %s"
 
 #: src/pulsemeeter/model/types.py:10
 msgid "Hardware Inputs"
@@ -375,4 +387,13 @@ msgstr "Fuentes virtuales de las que las aplicaciones pueden capturar audio."
 
 #~ msgid "Enable Tray"
 #~ msgstr "Habilitar Bandeja"
+
+#~ msgid "Select the %s"
+#~ msgstr "Seleccione el %s"
+
+#~ msgid "Enable or disable %s"
+#~ msgstr "Habilitar o deshabilitar %s"
+
+#~ msgid "Enter the %s"
+#~ msgstr "Ingrese el %s"
 

--- a/locale/pt_BR/LC_MESSAGES/pulsemeeter.po
+++ b/locale/pt_BR/LC_MESSAGES/pulsemeeter.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pulsemeeter 2.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 15:43-0600\n"
+"POT-Creation-Date: 2026-08-14 17:20-0600\n"
 "PO-Revision-Date: 2025-08-17 16:56-0300\n"
 "Last-Translator: XavierBit <github.com@mcm-swiss.net>\n"
 "Language: pt_BR\n"
@@ -148,9 +148,14 @@ msgstr ""
 msgid "Discord"
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:34
-#, python-format
-msgid "Select the app %s! device"
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:35
+#, fuzzy
+msgid "Select the output device for this app"
+msgstr "Selecione o aplicativo %s! dispositivo"
+
+#: src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py:37
+#, fuzzy
+msgid "Select the input device for this app"
 msgstr "Selecione o aplicativo %s! dispositivo"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:25
@@ -164,11 +169,6 @@ msgstr "Este dispositivo é o principal"
 #: src/pulsemeeter/clients/gtk/widgets/common/default_widget.py:36
 msgid "Set as primary device"
 msgstr "Definir como dispositivo principal"
-
-#: src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py:26
-#, python-format
-msgid "Select the %s"
-msgstr "Selecione o %s"
 
 #: src/pulsemeeter/clients/gtk/widgets/common/mute_widget.py:24
 msgid "Mute"
@@ -215,14 +215,13 @@ msgid "Open the welcome guide"
 msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
-#, python-format
-msgid "Enable or disable %s"
-msgstr "Ativar ou desativar %s"
-
-#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:41
-msgid "VU Meter (volume peak)"
+#, fuzzy
+msgid "Enable or disable VU meters (volume peak)"
 msgstr "Medidor VU (pico de volume)"
+
+#: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:42
+msgid "Enable or disable cleaning up devices and connections upon closing"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py:43
 msgid "Select the GUI layout"
@@ -271,9 +270,17 @@ msgstr ""
 msgid "Nick: "
 msgstr "Apelido:"
 
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:28
+msgid "Enter a nickname for the device"
+msgstr ""
+
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
 msgid "Name: "
 msgstr "Nome:"
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:29
+msgid "Enter a name for the device"
+msgstr ""
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:30
 #, fuzzy
@@ -288,22 +295,27 @@ msgid ""
 "create it onstartup or remove it on exit."
 msgstr ""
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
 msgid "Device: "
 msgstr "Dispositivo:"
 
-#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:37
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:38
+#, fuzzy
+msgid "Select a device"
+msgstr "Selecione o aplicativo %s! dispositivo"
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
 msgid "Channel Map: "
+msgstr "Mapa do canal:"
+
+#: src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py:40
+#, fuzzy
+msgid "Select a channel map"
 msgstr "Mapa do canal:"
 
 #: src/pulsemeeter/clients/gtk/widgets/popovers/edit_connection_widget.py:24
 msgid "Auto ports"
 msgstr "Portas automáticas"
-
-#: src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py:28
-#, python-format
-msgid "Enter the %s"
-msgstr "Insira o %s"
 
 #: src/pulsemeeter/model/types.py:10
 msgid "Hardware Inputs"
@@ -353,4 +365,13 @@ msgstr ""
 
 #~ msgid "Enable Tray"
 #~ msgstr "Ativar bandeja "
+
+#~ msgid "Select the %s"
+#~ msgstr "Selecione o %s"
+
+#~ msgid "Enable or disable %s"
+#~ msgstr "Ativar ou desativar %s"
+
+#~ msgid "Enter the %s"
+#~ msgstr "Insira o %s"
 

--- a/src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py
+++ b/src/pulsemeeter/clients/gtk/widgets/app/app_dropdown.py
@@ -31,7 +31,10 @@ class AppDropDown(Gtk.DropDown):
             model=self._string_list[app_type],
         )
 
-        accesible_description = _('Select the app %s! device') % app_type.split("_")[1]
+        if app_type == 'sink_input':
+            accesible_description = _('Select the output device for this app')
+        else:
+            accesible_description = _('Select the input device for this app')
         self.set_tooltip_text(accesible_description)
         Gtk.Accessible.update_property(
             self,

--- a/src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/common/dropdown_widget.py
@@ -1,12 +1,8 @@
-import gettext
-
 # pylint: disable=wrong-import-order,wrong-import-position
 import gi
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, GObject  # noqa: E402
 # pylint: enable=wrong-import-order,wrong-import-position
-
-_ = gettext.gettext
 
 
 class LabeledDropDown(Gtk.Grid):
@@ -18,12 +14,13 @@ class LabeledDropDown(Gtk.Grid):
         'changed': (GObject.SignalFlags.RUN_FIRST, GObject.TYPE_NONE, (str,)),
     }
 
-    def __init__(self, label):
+    def __init__(self, label, tooltip=None):
         super().__init__()
         self.label = Gtk.Label(label=label)
         self.string_list = Gtk.StringList()
         self.dropdown = Gtk.DropDown(model=self.string_list, hexpand=True)
-        self.dropdown.set_tooltip_text(_('Select the %s') % label.strip(':'))
+        if tooltip is not None:
+            self.dropdown.set_tooltip_text(tooltip)
         self.label.set_mnemonic_widget(self.dropdown)
         self.entry_list = None
 

--- a/src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py
+++ b/src/pulsemeeter/clients/gtk/widgets/containers/settings_menu_box.py
@@ -38,8 +38,8 @@ class SettingsMenuBox(Gtk.Box):
             [Gtk.AccessibleProperty.LABEL],
             [_('Open the welcome guide')]
         )
-        self.vumeters.set_tooltip_text(_('Enable or disable %s') % _('VU Meter (volume peak)'))
-        self.cleanup.set_tooltip_text(_('Enable or disable %s') % ('cleaning up devices and connections upon closing'))
+        self.vumeters.set_tooltip_text(_('Enable or disable VU meters (volume peak)'))
+        self.cleanup.set_tooltip_text(_('Enable or disable cleaning up devices and connections upon closing'))
         self.layout.set_tooltip_text(_('Select the GUI layout'))
 
         button_box = Gtk.Box(vexpand=False, halign=Gtk.Align.END, valign=Gtk.Align.END, spacing=6)

--- a/src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py
+++ b/src/pulsemeeter/clients/gtk/widgets/popovers/device_settings_popover.py
@@ -25,8 +25,8 @@ class DeviceSettingsPopover(Gtk.Popover):
         self.device_type = device_type
         self.edit = edit
 
-        self.nick_widget = InputWidget(_('Nick: '))
-        self.name_widget = InputWidget(_('Name: '))
+        self.nick_widget = InputWidget(_('Nick: '), tooltip=_('Enter a nickname for the device'))
+        self.name_widget = InputWidget(_('Name: '), tooltip=_('Enter a name for the device'))
         self.external_widget = Gtk.CheckButton(label=_('Externally Managed'))
         self.external_widget.set_tooltip_text(
             _("Check this if another application or config file owns this device's lifecycle (creates and destroys it), "
@@ -34,7 +34,10 @@ class DeviceSettingsPopover(Gtk.Popover):
               "startup or remove it on exit.")
         )
         self.port_selector = PortSelector()
-        self.combobox_widget = LabeledDropDown(_('Device: ') if device_type in ('a', 'hi') else _('Channel Map: '))
+        if device_type in ('a', 'hi'):
+            self.combobox_widget = LabeledDropDown(_('Device: '), tooltip=_('Select a device'))
+        else:
+            self.combobox_widget = LabeledDropDown(_('Channel Map: '), tooltip=_('Select a channel map'))
         self.confirm_button = Gtk.Button(label='Apply')
         self.remove_button = IconButton('user-trash-symbolic')
 

--- a/src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py
+++ b/src/pulsemeeter/clients/gtk/widgets/utils/input_widget.py
@@ -1,12 +1,8 @@
-import gettext
-
 # pylint: disable=wrong-import-order,wrong-import-position
 import gi
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk  # noqa: E402
 # pylint: enable=wrong-import-order,wrong-import-position
-
-_ = gettext.gettext
 
 
 class InputWidget(Gtk.Grid):
@@ -14,7 +10,7 @@ class InputWidget(Gtk.Grid):
     Widget for a labeled input option
     '''
 
-    def __init__(self, option_name: str, option_value=''):
+    def __init__(self, option_name: str, option_value='', tooltip=None):
         super().__init__()
         self.label = Gtk.Label(label=option_name)
 
@@ -25,7 +21,8 @@ class InputWidget(Gtk.Grid):
         self.input.set_accessible_role(Gtk.AccessibleRole.TEXT_BOX)
         self.label.set_mnemonic_widget(self.input)
         self.label.set_accessible_role(Gtk.AccessibleRole.LABEL)
-        self.input.set_tooltip_text(_("Enter the %s") % option_name.strip(': '))
+        if tooltip is not None:
+            self.input.set_tooltip_text(tooltip)
 
         self.attach(self.label, 0, 0, 1, 1)
         self.attach(self.input, 1, 0, 1, 1)


### PR DESCRIPTION
Substringing these strings make them hard to translate (Substituted text is not always in the same place for different languages/substituted text isn't known without finding the actual code, etc). They should be full strings for translations to be easy and accurate.