### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.callPackage ./packaging/nix/package.nix { };
+      }
+    );
+}

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  python3Packages,
+  libappindicator,
+  gobject-introspection,
+  wrapGAppsHook4,
+  bash,
+  pipewire,
+  gtk4,
+}:
+let
+  pname = "pulsemeeter";
+  src = ./../..;
+  version =
+    let
+      matches = builtins.match ".*VERSION = ['\"]([^'\"]+)['\"].*" (
+        builtins.readFile (src + "/src/${pname}/settings.py")
+      );
+    in
+    if matches == null then throw "VERSION not found in settings.py" else builtins.head matches;
+in
+python3Packages.buildPythonApplication {
+  pyproject = true;
+
+  inherit pname version src;
+
+  build-system = with python3Packages; [
+    setuptools
+    babel
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    pydantic
+    pulsectl
+    pulsectl-asyncio
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    libappindicator
+    pipewire
+    bash
+    gtk4
+  ];
+
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+  ];
+
+  dontWrapGApps = true;
+
+  pythonImportsCheck = [ pname ];
+
+  meta = {
+    description = "A pulseaudio and pipewire audio routing application";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/theRealCarneiro/pulsemeeter";
+    mainProgram = pname;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
# Description

This PR adds nix flake and packaging to this project. This will allow nix users to install or run pulsemeeter built from arbitrary branches or commits of this repository.

## Type of change

None of the check boxes in the PR template describe my change accurately.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Built and ran the program on my machine. To do so, run `nix build` or `nix run` in the root of the repo.

# Checklist : 
You don't need to do all of this, but at least check what you did
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

> [!IMPORTANT]
> I haven't changed the project's wiki. I couldn't find a way to do so. The text below is what I would add to the wiki under the installation section.

# Installation
## Nix/Nixos
### Nixpkgs package
The nixpkgs repository already contains the `pulsemeeter` package. You can add `pkgs.pulsemmeter` to your package list.
### Flakes
This repository has a nix flake, which allows for temporary runs with
```
nix run github:theRealCarneiro/pulsemeeter
``` 

To install it to your system, add
```nix
pulsemeeter = {
    url = "github:theRealCarneiro/pulsemeeter";
    inputs.nixpkgs.follows = "nixpkgs";
};
```
to the `inputs` of your flake then add it to your package list with 
```
inputs.pulsemeeter.packages.${pkgs.stdenv.system}.default
```